### PR TITLE
Add a cache wrapper to the mux example

### DIFF
--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -59,6 +59,7 @@ func main() {
 		limit.MaxAllowed(20),
 	}
 
+	// routerFactory := krakendgin.DefaultFactory(proxy.DefaultFactory(logger), logger)
 	routerFactory := krakendgin.NewFactory(krakendgin.Config{
 		Engine:       gin.Default(),
 		ProxyFactory: customProxyFactory{logger, proxy.DefaultFactory(logger)},

--- a/examples/mux/Makefile
+++ b/examples/mux/Makefile
@@ -15,6 +15,7 @@ deps:
 	go get "github.com/devopsfaith/krakend/router/mux"
 	go get "github.com/devopsfaith/krakend/logging/gologging"
 	go get "gopkg.in/unrolled/secure.v1"
+	go get "github.com/geekypanda/httpcache"
 
 build:
 	go build -a -ldflags="-X github.com/devopsfaith/krakend/core.KrakendVersion=${KRAKEND_VERSION}" -o ${BIN_NAME}


### PR DESCRIPTION
As requested in #18 , this PR shows how to integrate a cache lib into the `mux` router adapter available in the framework