### PR TITLE
accept collections as responses from backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ deps:
 	go get -u github.com/spf13/viper
 	go get -u github.com/op/go-logging
 	go get -u github.com/gorilla/mux
+	go get -u github.com/clbanning/mxj/x2j
 
 test:
 	go fmt ./...

--- a/config/config.go
+++ b/config/config.go
@@ -186,25 +186,12 @@ func (s *ServiceConfig) initBackendDefaults(e, b int) {
 	}
 	backend.Timeout = endpoint.Timeout
 	backend.ConcurrentCalls = endpoint.ConcurrentCalls
-	if backend.IsCollection {
-		backend.Decoder = s.getCollectionDecoder(backend.Encoding)
-	} else {
-		backend.Decoder = s.getEntityDecoder(backend.Encoding)
+	switch strings.ToLower(backend.Encoding) {
+	case encoding.XML:
+		backend.Decoder = encoding.NewXMLDecoder(backend.IsCollection)
+	default:
+		backend.Decoder = encoding.NewJSONDecoder(backend.IsCollection)
 	}
-}
-
-func (ServiceConfig) getEntityDecoder(format string) encoding.Decoder {
-	if strings.ToLower(format) == "xml" {
-		return encoding.XMLDecoder
-	}
-	return encoding.JSONDecoder
-}
-
-func (ServiceConfig) getCollectionDecoder(format string) encoding.Decoder {
-	if strings.ToLower(format) == "xml" {
-		return encoding.XMLCollectionDecoder
-	}
-	return encoding.JSONCollectionDecoder
 }
 
 func (s *ServiceConfig) initBackendURLMappings(e, b int, inputParams map[string]interface{}) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -186,8 +186,7 @@ func TestConfig_initBackendURLMappings_undefinedOutput(t *testing.T) {
 
 func TestConfig_init(t *testing.T) {
 	supuBackend := Backend{
-		URLPattern:   "/__debug/supu",
-		IsCollection: true,
+		URLPattern: "/__debug/supu",
 	}
 	supuEndpoint := EndpointConfig{
 		Endpoint: "/supu",
@@ -213,14 +212,12 @@ func TestConfig_init(t *testing.T) {
 		URLPattern: "/users/{user}",
 		Host:       []string{"https://jsonplaceholder.typicode.com"},
 		Mapping:    map[string]string{"email": "personal_email"},
-		Encoding:   "xml",
 	}
 	postBackend := Backend{
-		URLPattern:   "/posts/{user}",
-		Host:         []string{"https://jsonplaceholder.typicode.com"},
-		Group:        "posts",
-		Encoding:     "xml",
-		IsCollection: true,
+		URLPattern: "/posts/{user}",
+		Host:       []string{"https://jsonplaceholder.typicode.com"},
+		Group:      "posts",
+		Encoding:   "xml",
 	}
 	userEndpoint := EndpointConfig{
 		Endpoint: "/users/{user}",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -186,7 +186,8 @@ func TestConfig_initBackendURLMappings_undefinedOutput(t *testing.T) {
 
 func TestConfig_init(t *testing.T) {
 	supuBackend := Backend{
-		URLPattern: "/__debug/supu",
+		URLPattern:   "/__debug/supu",
+		IsCollection: true,
 	}
 	supuEndpoint := EndpointConfig{
 		Endpoint: "/supu",
@@ -212,12 +213,14 @@ func TestConfig_init(t *testing.T) {
 		URLPattern: "/users/{user}",
 		Host:       []string{"https://jsonplaceholder.typicode.com"},
 		Mapping:    map[string]string{"email": "personal_email"},
+		Encoding:   "xml",
 	}
 	postBackend := Backend{
-		URLPattern: "/posts/{user}",
-		Host:       []string{"https://jsonplaceholder.typicode.com"},
-		Group:      "posts",
-		Encoding:   "xml",
+		URLPattern:   "/posts/{user}",
+		Host:         []string{"https://jsonplaceholder.typicode.com"},
+		Group:        "posts",
+		Encoding:     "xml",
+		IsCollection: true,
 	}
 	userEndpoint := EndpointConfig{
 		Endpoint: "/users/{user}",

--- a/encoding/json.go
+++ b/encoding/json.go
@@ -5,6 +5,17 @@ import (
 	"io"
 )
 
+// JSON is the key for the json encoding
+const JSON = "json"
+
+// NewJSONDecoder return the right JSON decoder
+func NewJSONDecoder(isCollection bool) Decoder {
+	if isCollection {
+		return JSONCollectionDecoder
+	}
+	return JSONDecoder
+}
+
 // JSONDecoder implements the Decoder interface
 func JSONDecoder(r io.Reader, v *map[string]interface{}) error {
 	d := json.NewDecoder(r)

--- a/encoding/json.go
+++ b/encoding/json.go
@@ -11,3 +11,15 @@ func JSONDecoder(r io.Reader, v *map[string]interface{}) error {
 	d.UseNumber()
 	return d.Decode(v)
 }
+
+// JSONCollectionDecoder implements the Decoder interface over a collection
+func JSONCollectionDecoder(r io.Reader, v *map[string]interface{}) error {
+	var collection []interface{}
+	d := json.NewDecoder(r)
+	d.UseNumber()
+	if err := d.Decode(&collection); err != nil {
+		return err
+	}
+	*(v) = map[string]interface{}{"collection": collection}
+	return nil
+}

--- a/encoding/json_test.go
+++ b/encoding/json_test.go
@@ -1,0 +1,63 @@
+package encoding
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewJSONDecoder_map(t *testing.T) {
+	decoder := NewJSONDecoder(false)
+	original := strings.NewReader(`{"foo": "bar", "supu": false, "tupu": 4.20}`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 3 {
+		t.Error("Unexpected result:", result)
+	}
+	if v, ok := result["foo"]; !ok || v.(string) != "bar" {
+		t.Error("wrong result:", result)
+	}
+	if v, ok := result["supu"]; !ok || v.(bool) {
+		t.Error("wrong result:", result)
+	}
+	if v, ok := result["tupu"]; !ok || v.(json.Number).String() != "4.20" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewJSONDecoder_collection(t *testing.T) {
+	decoder := NewJSONDecoder(true)
+	original := strings.NewReader(`["foo", "bar", "supu"]`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 1 {
+		t.Error("Unexpected result:", result)
+	}
+	v, ok := result["collection"]
+	if !ok {
+		t.Error("wrong result:", result)
+	}
+	embedded := v.([]interface{})
+	if embedded[0].(string) != "foo" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[1].(string) != "bar" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[2].(string) != "supu" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewJSONDecoder_ko(t *testing.T) {
+	decoder := NewJSONDecoder(true)
+	original := strings.NewReader(`3`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err == nil {
+		t.Error("Expecting error!")
+	}
+}

--- a/encoding/xml.go
+++ b/encoding/xml.go
@@ -9,3 +9,13 @@ import (
 func XMLDecoder(r io.Reader, v *map[string]interface{}) error {
 	return xml.NewDecoder(r).Decode(v)
 }
+
+// XMLCollectionDecoder implements the Decoder interface over a collection
+func XMLCollectionDecoder(r io.Reader, v *map[string]interface{}) error {
+	var collection []interface{}
+	if err := xml.NewDecoder(r).Decode(&collection); err != nil {
+		return err
+	}
+	*(v) = map[string]interface{}{"collection": collection}
+	return nil
+}

--- a/encoding/xml.go
+++ b/encoding/xml.go
@@ -1,21 +1,39 @@
 package encoding
 
 import (
-	"encoding/xml"
 	"io"
+
+	"github.com/clbanning/mxj"
 )
+
+// XML is the key for the xml encoding
+const XML = "xml"
+
+// NewXMLDecoder return the right XML decoder
+func NewXMLDecoder(isCollection bool) Decoder {
+	if isCollection {
+		return XMLCollectionDecoder
+	}
+	return XMLDecoder
+}
 
 // XMLDecoder implements the Decoder interface
 func XMLDecoder(r io.Reader, v *map[string]interface{}) error {
-	return xml.NewDecoder(r).Decode(v)
+	mv, err := mxj.NewMapXmlReader(r)
+	if err != nil {
+		return err
+	}
+	*v = mv
+	return nil
+
 }
 
 // XMLCollectionDecoder implements the Decoder interface over a collection
 func XMLCollectionDecoder(r io.Reader, v *map[string]interface{}) error {
-	var collection []interface{}
-	if err := xml.NewDecoder(r).Decode(&collection); err != nil {
+	mv, err := mxj.NewMapXmlReader(r)
+	if err != nil {
 		return err
 	}
-	*(v) = map[string]interface{}{"collection": collection}
+	*(v) = map[string]interface{}{"collection": mv}
 	return nil
 }

--- a/encoding/xml_test.go
+++ b/encoding/xml_test.go
@@ -1,0 +1,99 @@
+package encoding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clbanning/mxj"
+)
+
+func TestNewXMLDecoder_map(t *testing.T) {
+	decoder := NewXMLDecoder(false)
+	original := strings.NewReader(`
+			<Person id="1">
+				<FullName>Alice</FullName>
+				<Company>Acme</Company>
+				<Email where="home">
+					<Addr>gre@example.com</Addr>
+				</Email>
+				<Email where='work'>
+					<Addr>gre@work.com</Addr>
+				</Email>
+				<Group>
+					<Value>Friends</Value>
+					<Value>Squash</Value>
+				</Group>
+			</Person>
+		`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 1 {
+		t.Error("Unexpected result:", result)
+	}
+	if v, ok := result["Person"]; !ok || len(v.(map[string]interface{})) != 5 {
+		t.Error("result with wrong len:", result)
+	}
+	if result["Person"].(map[string]interface{})["FullName"] != "Alice" {
+		t.Error("wrong result:", result)
+	}
+	if result["Person"].(map[string]interface{})["Company"] != "Acme" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewXMLDecoder_collection(t *testing.T) {
+	decoder := NewXMLDecoder(true)
+	original := strings.NewReader(`
+		<People>
+			<Person id="1">
+				<FullName>Alice</FullName>
+				<Company>Acme</Company>
+			</Person>
+			<Person id="2">
+				<FullName>Bob</FullName>
+				<Company>Acme</Company>
+			</Person>
+			<Person id="3">
+				<FullName>Charles</FullName>
+				<Company>Acme</Company>
+			</Person>
+		</People>
+			`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 1 {
+		t.Error("Unexpected result:", result)
+	}
+	v, ok := result["collection"]
+	if !ok {
+		t.Error("wrong result:", result)
+	}
+	embedded := v.(mxj.Map).Old()["People"].(map[string]interface{})["Person"].([]interface{})
+	if len(embedded) != 3 {
+		t.Error("wrong result:", embedded)
+	}
+	if embedded[0].(map[string]interface{})["FullName"].(string) != "Alice" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[1].(map[string]interface{})["FullName"].(string) != "Bob" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[2].(map[string]interface{})["FullName"].(string) != "Charles" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewXMLDecoder_ko(t *testing.T) {
+	for _, testCase := range []bool{true, false} {
+		decoder := NewXMLDecoder(testCase)
+		original := strings.NewReader(`3`)
+		var result map[string]interface{}
+		if err := decoder(original, &result); err == nil {
+			t.Error("Expecting error!")
+		}
+	}
+}


### PR DESCRIPTION
As requested in #21 , this PR adds support for collections as backend responses

In order to consume backend exposing collections, users must add the `is_collection` param in the backend config:

```
        {
            "endpoint": "/combination/{id}",
            "method": "GET",
            "backend": [
                {
                    "host": [
                        "https://jsonplaceholder.typicode.com"
                    ],
                    "url_pattern": "/posts?userId={id}",
                    "is_collection": true,
                    "mapping": {
                        "collection": "posts"
                    }
                },
                {
                    "host": [
                        "https://jsonplaceholder.typicode.com"
                    ],
                    "url_pattern": "/users/{id}",
                    "mapping": {
                        "email": "personal_email"
                    }
                }
            ]
        }
```