### PR TITLE
Support middleware on specific endpoint

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -249,7 +249,6 @@ func TestConfig_initKOInvalidDebugPattern(t *testing.T) {
 	debugPattern = dp
 }
 
-
 func TestDefaultConfigGetter(t *testing.T) {
 	getter, ok := ConfigGetters[defaultNamespace]
 	if !ok {

--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -45,7 +45,7 @@ func NewMergeDataMiddleware(endpointConfig *config.EndpointConfig) Middleware {
 			}
 			if isEmpty {
 				cancel()
-				return &Response{Data: make(map[string]interface{}, 0),IsComplete: false}, err
+				return &Response{Data: make(map[string]interface{}, 0), IsComplete: false}, err
 			}
 
 			result := combineData(localCtx, totalBackends, responses)
@@ -92,5 +92,5 @@ func combineData(ctx context.Context, total int, parts []*Response) *Response {
 		}
 	}
 
-	return &Response{Data: composedData,IsComplete: isComplete}
+	return &Response{Data: composedData, IsComplete: isComplete}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,13 +17,11 @@ type Response struct {
 	Io         io.Reader
 }
 
-
 // readCloserWrapper is Io.Reader which is closed when the Context is closed or canceled
 type readCloserWrapper struct {
 	ctx context.Context
 	rc  io.ReadCloser
 }
-
 
 // NewReadCloserWrapper Creates a new closeable io.Read
 func NewReadCloserWrapper(ctx context.Context, in io.ReadCloser) io.Reader {
@@ -31,7 +29,6 @@ func NewReadCloserWrapper(ctx context.Context, in io.ReadCloser) io.Reader {
 	go wrapper.closeOnCancel()
 	return wrapper
 }
-
 
 func (w readCloserWrapper) Read(b []byte) (int, error) {
 	return w.rc.Read(b)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,13 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 	"time"
-	"bytes"
-	"fmt"
 )
 
 func TestEmptyMiddleware_ok(t *testing.T) {

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -139,7 +139,9 @@ func (r httpRouter) registerKrakendEndpoint(method, path string, handler http.Ha
 func (r httpRouter) handler() http.Handler {
 	var handler http.Handler
 	handler = r.cfg.Engine
-	for _, middleware := range r.cfg.Middlewares {
+	count := len(r.cfg.Middlewares)
+	for i := range r.cfg.Middlewares {
+		middleware := r.cfg.Middlewares[count-1-i]
 		r.cfg.Logger.Debug("Adding the middleware", middleware)
 		handler = middleware.Handler(handler)
 	}


### PR DESCRIPTION
Considering authentication, some endpoint may require to be authenticated (account update is an exemple) and some other may be publicly available without authentication (reaching public profile information).

To implement such a feature, several options are available including:
- Add a global middleware matching itself the authenticated endpoint
- Add an authentication middleware only on endpoints that require authentication

In the first option, the middleware should have to perform operations similar to what the http router already does and thus would add some latency to each request.

The second option has the advantage of adding the computation time at startup, when creating middlewares, and leaving middleware to do their goal: authentication (or any other middleware core logic), leaving the route selection to the router, already implemented