### PR TITLE
[WIP] Add support to martian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps test build benchmark coveralls build_gin_example build_dns_example build_mux_example build_gorilla_example build_negroni_example build_httpcache_example build_rss_example build_jwt_example build_etcd_example
+.PHONY: all deps test build benchmark coveralls build_gin_example build_dns_example build_mux_example build_gorilla_example build_negroni_example build_httpcache_example build_rss_example build_jwt_example build_etcd_example build_martian_example
 
 PACKAGES = $(shell go list ./... | grep -v /examples/)
 
@@ -13,6 +13,10 @@ deps:
 	go get -u github.com/clbanning/mxj/x2j
 	go get -u github.com/mmcdole/gofeed
 	go get -u github.com/coreos/etcd/client
+	go get -u github.com/google/martian/body
+	go get -u github.com/google/martian/fifo
+	go get -u github.com/google/martian/header
+	go get -u github.com/google/martian/parse
 
 test:
 	go fmt ./...
@@ -22,7 +26,7 @@ test:
 benchmark:
 	go test -bench=. -benchtime=3s $(PACKAGES)
 
-build: build_gin_example build_dns_example build_mux_example build_gorilla_example build_negroni_example build_httpcache_example build_rss_example build_jwt_example build_etcd_example
+build: build_gin_example build_dns_example build_mux_example build_gorilla_example build_negroni_example build_httpcache_example build_rss_example build_jwt_example build_etcd_example build_martian_example
 
 build_gin_example:
 	cd examples/gin/ && make && cd ../.. && cp examples/gin/krakend_gin_example* .
@@ -50,6 +54,9 @@ build_jwt_example:
 
 build_etcd_example:
 	cd examples/etcd/ && make && cd ../.. && cp examples/etcd/krakend_etcd_example* .
+
+build_martian_example:
+	cd examples/martian/ && make && cd ../.. && cp examples/martian/krakend_martian_example* .
 
 coveralls: all
 	go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Visit the [framework overview](/docs/OVERVIEW.md) for more details about the com
 7. [jwt middlewares](/examples/jwt/README.md)
 8. [httpcache based proxies](/examples/httpcache/README.md)
 9. [etcd service discovery](/examples/httpcache/README.md)
+10. [martian](/examples/martian/README.md)
 
 ## Configuration file
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -249,7 +249,6 @@ func TestConfig_initKOInvalidDebugPattern(t *testing.T) {
 	debugPattern = dp
 }
 
-
 func TestDefaultConfigGetter(t *testing.T) {
 	getter, ok := ConfigGetters[defaultNamespace]
 	if !ok {

--- a/examples/martian/Makefile
+++ b/examples/martian/Makefile
@@ -1,0 +1,21 @@
+.PHONY: all deps build
+
+# This Makefile is a simple example that demonstrates usual steps to build a binary that can be run in the same
+# architecture that was compiled in. The "ldflags" in the build assure that any needed dependency is included in the
+# binary and no external dependencies are needed to run the service.
+
+KRAKEND_VERSION=$(shell git describe --always --long --dirty --tags)
+BIN_NAME=krakend_martian_example_${KRAKEND_VERSION}
+
+all: deps build
+
+deps:
+	go get "github.com/devopsfaith/krakend/config/viper"
+	go get "github.com/devopsfaith/krakend/proxy"
+	go get "github.com/devopsfaith/krakend/proxy/martian"
+	go get "github.com/devopsfaith/krakend/router/gin"
+	go get "github.com/devopsfaith/krakend/logging/gologging"
+
+build:
+	go build -a -ldflags="-X github.com/devopsfaith/krakend/core.KrakendVersion=${KRAKEND_VERSION}" -o ${BIN_NAME}
+	@echo "You can now use ./${BIN_NAME}"

--- a/examples/martian/README.md
+++ b/examples/martian/README.md
@@ -1,0 +1,22 @@
+Krakend Martian example
+====
+
+## Build
+
+Go 1.8 is a requirement
+
+	$ make
+
+## Run
+
+Running it as a common executable, logs are send to the stdOut and some options are available at the CLI
+
+	$ ./krakend_martian_example
+	Usage of ./krakend_martian_example:
+	  -c string
+	    	Path to the configuration filename (default "/etc/krakend/configuration.json")
+	  -d	Enable the debug
+	  -l string
+	    	Logging level (default "ERROR")
+	  -p int
+	    	Port of the service

--- a/examples/martian/main.go
+++ b/examples/martian/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/devopsfaith/krakend/config/viper"
+	"github.com/devopsfaith/krakend/logging/gologging"
+	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/proxy/martian"
+	krakendgin "github.com/devopsfaith/krakend/router/gin"
+)
+
+func main() {
+	port := flag.Int("p", 0, "Port of the service")
+	logLevel := flag.String("l", "ERROR", "Logging level")
+	debug := flag.Bool("d", false, "Enable the debug")
+	configFile := flag.String("c", "/etc/krakend/configuration.json", "Path to the configuration filename")
+	flag.Parse()
+
+	parser := viper.New()
+	serviceConfig, err := parser.Parse(*configFile)
+	if err != nil {
+		log.Fatal("ERROR:", err.Error())
+	}
+	serviceConfig.Debug = serviceConfig.Debug || *debug
+	if *port != 0 {
+		serviceConfig.Port = *port
+	}
+
+	logger, err := gologging.NewLogger(*logLevel, os.Stdout, "[KRAKEND]")
+	if err != nil {
+		log.Fatal("ERROR:", err.Error())
+	}
+
+	logger.Debug("config:", serviceConfig)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	routerFactory := krakendgin.NewFactory(krakendgin.Config{
+		Engine:         gin.Default(),
+		Middlewares:    []gin.HandlerFunc{},
+		Logger:         logger,
+		HandlerFactory: krakendgin.EndpointHandler,
+		ProxyFactory:   proxy.NewDefaultFactory(martian.NewBackendFactory(logger, proxy.DefaultHTTPRequestExecutor(proxy.NewHTTPClient)), logger),
+	})
+
+	routerFactory.NewWithContext(ctx).Run(serviceConfig)
+
+	cancel()
+}

--- a/proxy/martian/martian.go
+++ b/proxy/martian/martian.go
@@ -1,0 +1,59 @@
+package martian
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	_ "github.com/google/martian/body"
+	_ "github.com/google/martian/fifo"
+	_ "github.com/google/martian/header"
+	"github.com/google/martian/parse"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/logging"
+	"github.com/devopsfaith/krakend/proxy"
+)
+
+func NewBackendFactory(logger logging.Logger, re proxy.HTTPRequestExecutor) proxy.BackendFactory {
+	return func(remote *config.Backend) proxy.Proxy {
+		martian, err := Parse(remote.ExtraConfig)
+		if err != nil {
+			logger.Error(err)
+			return proxy.NewHTTPProxyWithHTTPExecutor(remote, re, remote.Decoder)
+		}
+		return proxy.NewHTTPProxyWithHTTPExecutor(remote, HTTPRequestExecutor(martian, re), remote.Decoder)
+	}
+}
+
+func HTTPRequestExecutor(result *parse.Result, re proxy.HTTPRequestExecutor) proxy.HTTPRequestExecutor {
+	return func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		result.RequestModifier().ModifyRequest(req)
+		resp, err := re(ctx, req)
+		result.ResponseModifier().ModifyResponse(resp)
+		return resp, err
+	}
+}
+
+func Parse(e config.ExtraConfig) (*parse.Result, error) {
+	cfg, ok := e[Namespace]
+	if !ok {
+		return nil, fmt.Errorf("getting the extra config for the martian proxy")
+	}
+
+	data, ok := cfg.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("casting the extra config for the martian proxy")
+	}
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling the extra config for the martian proxy")
+	}
+
+	return parse.FromJSON(raw)
+}
+
+// Namespace is the key to look for extra configuration details
+const Namespace = "github.com/krakend/proxy/martian"

--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -45,7 +45,7 @@ func NewMergeDataMiddleware(endpointConfig *config.EndpointConfig) Middleware {
 			}
 			if isEmpty {
 				cancel()
-				return &Response{Data: make(map[string]interface{}, 0),IsComplete: false}, err
+				return &Response{Data: make(map[string]interface{}, 0), IsComplete: false}, err
 			}
 
 			result := combineData(localCtx, totalBackends, responses)
@@ -92,5 +92,5 @@ func combineData(ctx context.Context, total int, parts []*Response) *Response {
 		}
 	}
 
-	return &Response{Data: composedData,IsComplete: isComplete}
+	return &Response{Data: composedData, IsComplete: isComplete}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,13 +17,11 @@ type Response struct {
 	Io         io.Reader
 }
 
-
 // readCloserWrapper is Io.Reader which is closed when the Context is closed or canceled
 type readCloserWrapper struct {
 	ctx context.Context
 	rc  io.ReadCloser
 }
-
 
 // NewReadCloserWrapper Creates a new closeable io.Read
 func NewReadCloserWrapper(ctx context.Context, in io.ReadCloser) io.Reader {
@@ -31,7 +29,6 @@ func NewReadCloserWrapper(ctx context.Context, in io.ReadCloser) io.Reader {
 	go wrapper.closeOnCancel()
 	return wrapper
 }
-
 
 func (w readCloserWrapper) Read(b []byte) (int, error) {
 	return w.rc.Read(b)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,13 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 	"time"
-	"bytes"
-	"fmt"
 )
 
 func TestEmptyMiddleware_ok(t *testing.T) {


### PR DESCRIPTION
Initial implementation of the issue #36 

### How to use it

add your martian DSL definition under the "github.com/krakend/proxy/martian" namespace of the backend section of the config file

```
"extra_config": {
                        "github.com/krakend/proxy/martian": {}
}
```

More details here: https://github.com/google/martian#modifiers-all-the-way-down