### PR TITLE
Use type for Metadata

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -9,11 +9,15 @@ import (
 	"github.com/devopsfaith/krakend/config"
 )
 
+type Metadata struct {
+	Headers map[string][]string
+}
+
 // Response is the entity returned by the proxy
 type Response struct {
 	Data       map[string]interface{}
 	IsComplete bool
-	Metadata   map[string]string
+	Metadata   Metadata
 	Io         io.Reader
 }
 


### PR DESCRIPTION
Using Krakend to serve html content, my servers often send Set-Cookie headers.
I often have response headers like:

```
Set-Cookie: cookieName=; Expires=Thu, 01 Jan 1970 00:00:01 GMT
Set-Cookie: cookieName2=value; Path=/; Max-Age=3600
```
To forward those cookies, I am using the `Response.Metadata` field of `proxy/proxy.go`, joining cookie headers using:
```
var response proxy.Response
response.Metadata["Set-Cookie"] = strings.Join(resp.Headers["Set-Cookie"], ",")
```
and setting the header back to with

```
for header, value := range response.Metadata {
    c.Header(header, value)
}
```

Increase the support for multiple Headers by introducing a Metadata
type.

solves #48

Signed-off-by: Thibault Jamet <thibault.jamet@schibsted.com>