### PR TITLE
reduce whitelisting filter creation function size

### DIFF
--- a/proxy/formatter.go
+++ b/proxy/formatter.go
@@ -84,20 +84,13 @@ func newWhitelistingFilter(whitelist []string) propertyFilter {
 	wl := make(map[string]map[string]interface{}, len(whitelist))
 	for _, k := range whitelist {
 		keys := strings.Split(k, ".")
-		tmp := make(map[string]interface{}, len(keys)-1)
-		if len(keys) > 1 {
-			if _, ok := wl[keys[0]]; ok {
-				for _, k := range keys[1:] {
-					wl[keys[0]][k] = nil
-				}
-			} else {
-				for _, k := range keys[1:] {
-					tmp[k] = nil
-				}
-				wl[keys[0]] = tmp
-			}
-		} else {
+		tmp, ok := wl[keys[0]]
+		if !ok {
+			tmp = make(map[string]interface{}, len(keys)-1)
 			wl[keys[0]] = tmp
+		}
+		for idx := 1; idx < len(keys); idx++ {
+			tmp[keys[idx]] = nil
 		}
 	}
 


### PR DESCRIPTION
_Disclaimer_: I've read the ```CONTRIBUTING.md```file, but I just was trying to read the code, and learn from it doing some changes.

I think (not sure), that the code does exactly the same but with fewer lines. 

I do not know if affects performance, (I think it avoids to create ```tmp``` map when not needed) but I think that performance in building the white list  filter is not important (only used when reading the conf, I guess).
