### PR TITLE
Support func versions of every interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ deps:
 
 test:
 	go fmt ./...
-	go test -cover $(PACKAGES)
+	go test -v -cover $(PACKAGES)
 	go vet ./...
 
 benchmark:

--- a/config/parser.go
+++ b/config/parser.go
@@ -4,3 +4,7 @@ package config
 type Parser interface {
 	Parse(configFile string) (ServiceConfig, error)
 }
+
+type ParserFunc func(string) (ServiceConfig, error)
+
+func (f ParserFunc) Parse(configFile string) (ServiceConfig, error) { return f(configFile) }

--- a/config/parser.go
+++ b/config/parser.go
@@ -5,6 +5,9 @@ type Parser interface {
 	Parse(configFile string) (ServiceConfig, error)
 }
 
+// ParserFunc type is an adapter to allow the use of ordinary functions as subscribers.
+// If f is a function with the appropriate signature, ParserFunc(f) is a Parser that calls f.
 type ParserFunc func(string) (ServiceConfig, error)
 
+// Parse implements the Parser interface
 func (f ParserFunc) Parse(configFile string) (ServiceConfig, error) { return f(configFile) }

--- a/proxy/factory.go
+++ b/proxy/factory.go
@@ -15,6 +15,13 @@ type Factory interface {
 	New(cfg *config.EndpointConfig) (Proxy, error)
 }
 
+// FactoryFunc type is an adapter to allow the use of ordinary functions as proxy factories.
+// If f is a function with the appropriate signature, FactoryFunc(f) is a Factory that calls f.
+type FactoryFunc func(*config.EndpointConfig) (Proxy, error)
+
+// New implements the Factory interface
+func (f FactoryFunc) New(cfg *config.EndpointConfig) (Proxy, error) { return f(cfg) }
+
 // DefaultFactory returns a default http proxy factory with the injected logger
 func DefaultFactory(logger logging.Logger) Factory {
 	return NewDefaultFactory(httpProxy, logger)

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -51,6 +51,7 @@ func (rf factory) New() router.Router {
 	return ginRouter{rf.cfg, context.Background()}
 }
 
+// NewWithContext implements the factory interface
 func (rf factory) NewWithContext(ctx context.Context) router.Router {
 	return ginRouter{rf.cfg, ctx}
 }

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -81,7 +81,7 @@ type ParamExtractor func(r *http.Request) map[string]string
 
 // NewRequest is a RequestBuilder that creates a proxy request from the received http request without
 // processing the uri params
-var NewRequest = NewRequestBuilder(func(r *http.Request) map[string]string {
+var NewRequest = NewRequestBuilder(func(_ *http.Request) map[string]string {
 	return map[string]string{}
 })
 

--- a/router/router.go
+++ b/router/router.go
@@ -9,11 +9,18 @@ import (
 
 // Router sets up the public layer exposed to the users
 type Router interface {
-	Run(cfg config.ServiceConfig)
+	Run(config.ServiceConfig)
 }
+
+// FactoryFunc type is an adapter to allow the use of ordinary functions as routers.
+// If f is a function with the appropriate signature, RouterFunc(f) is a Router that calls f.
+type RouterFunc func(config.ServiceConfig)
+
+// New implements the Router interface
+func (f RouterFunc) Run(cfg config.ServiceConfig) { f(cfg) }
 
 // Factory creates new routers
 type Factory interface {
 	New() Router
-	NewWithContext(ctx context.Context) Router
+	NewWithContext(context.Context) Router
 }

--- a/sd/subscriber.go
+++ b/sd/subscriber.go
@@ -10,6 +10,13 @@ type Subscriber interface {
 	Hosts() ([]string, error)
 }
 
+// SubscriberFunc type is an adapter to allow the use of ordinary functions as subscribers.
+// If f is a function with the appropriate signature, SubscriberFunc(f) is a Subscriber that calls f.
+type SubscriberFunc func() ([]string, error)
+
+// New implements the Subscriber interface by executing the wrapped function
+func (f SubscriberFunc) Hosts() ([]string, error) { return f() }
+
 // FixedSubscriber has a constant set of backend hosts and they never get updated
 type FixedSubscriber []string
 


### PR DESCRIPTION
so users can create the simplest implementations