### PR TITLE
Unlimit whitelist depth

### DIFF
--- a/proxy/formatter.go
+++ b/proxy/formatter.go
@@ -83,25 +83,25 @@ func newWhitelistingFilter(whitelist []string) propertyFilter {
 	}
 	wlIndices := make([]int, len(whitelist))
 	wlFields := make([]string, numFields)
-	f_idx := 0
-	for w_idx, k := range whitelist {
+	fIdx := 0
+	for wIdx, k := range whitelist {
 		for _, key := range strings.Split(k, ".") {
-			wlFields[f_idx] = key
-			f_idx++
+			wlFields[fIdx] = key
+			fIdx++
 		}
-		wlIndices[w_idx] = f_idx
+		wlIndices[wIdx] = fIdx
 	}
 
 	return func(entity *Response) {
 		accumulator := make(map[string]interface{}, len(whitelist))
 		start := 0
 		for _, end := range wlIndices {
-			d_end := end - 1
-            p := findDictPath(entity.Data, wlFields[start:d_end]);
-            if value, ok := p[wlFields[d_end]]; ok {
-                d := buildDictPath(accumulator, wlFields[start:d_end], value)
-                d[wlFields[d_end]] = value
-            }
+			dEnd := end - 1
+			p := findDictPath(entity.Data, wlFields[start:dEnd])
+			if value, ok := p[wlFields[dEnd]]; ok {
+				d := buildDictPath(accumulator, wlFields[start:dEnd])
+				d[wlFields[dEnd]] = value
+			}
 			start = end
 		}
 		*entity = Response{Data: accumulator, IsComplete: entity.IsComplete}
@@ -109,42 +109,35 @@ func newWhitelistingFilter(whitelist []string) propertyFilter {
 }
 
 func findDictPath(root map[string]interface{}, fields []string) map[string]interface{} {
-    ok := true
-    var p map[string]interface{}
-    var c interface{}
-
-    p = root
-    for _, field := range fields {
-        if c, ok = p[field]; !ok {
-            return nil
-        }
-        if p, ok = c.(map[string]interface{}); !ok {
-            return nil
-        }
-    }
-    return p
-}
-
-func buildDictPath(accumulator map[string]interface{}, fields []string, value interface{}) map[string]interface{} {
-	var ok bool = true
-	var c map[string]interface{}
-	var f_idx int
-    f_end := len(fields)
-	p := accumulator
-	for f_idx = 0; f_idx < f_end; f_idx++ {
-		if c, ok = p[fields[f_idx]].(map[string]interface{}); !ok {
-			break
+	ok := true
+	p := root
+	for _, field := range fields {
+		if p, ok = p[field].(map[string]interface{}); !ok {
+			return nil
 		}
-		p = c
-	}
-	for ; f_idx < f_end; f_idx++ {
-		c = make(map[string]interface{})
-		p[fields[f_idx]] = c
-		p = c
 	}
 	return p
 }
 
+func buildDictPath(accumulator map[string]interface{}, fields []string) map[string]interface{} {
+	var ok bool = true
+	var c map[string]interface{}
+	var fIdx int
+	fEnd := len(fields)
+	p := accumulator
+	for fIdx = 0; fIdx < fEnd; fIdx++ {
+		if c, ok = p[fields[fIdx]].(map[string]interface{}); !ok {
+			break
+		}
+		p = c
+	}
+	for ; fIdx < fEnd; fIdx++ {
+		c = make(map[string]interface{})
+		p[fields[fIdx]] = c
+		p = c
+	}
+	return p
+}
 
 func newBlacklistingFilter(blacklist []string) propertyFilter {
 	bl := make(map[string][]string, len(blacklist))

--- a/proxy/formatter_benchmark_test.go
+++ b/proxy/formatter_benchmark_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 )
@@ -39,6 +40,64 @@ func BenchmarkEntityFormatter_whitelistingFilter(b *testing.B) {
 		}
 	}
 
+}
+
+func benchmarkDeepChilds(depth int, extraSiblings int) map[string]interface{} {
+	data := make(map[string]interface{}, extraSiblings+1)
+	for i := 0; i < extraSiblings; i++ {
+		data[fmt.Sprintf("extra%d", i)] = "sibling_value"
+	}
+	if depth > 0 {
+		data[fmt.Sprintf("child%d", depth)] = benchmarkDeepChilds(depth-1, extraSiblings)
+	} else {
+		data["child0"] = 1
+	}
+	return data
+}
+
+func benchmarkDeepStructure(numTargets int, targetDepth int, extraFields int, extraSiblings int) (map[string]interface{}, []string) {
+	data := make(map[string]interface{}, numTargets+extraFields)
+	target_keys := make([]string, numTargets)
+	for i := 0; i < numTargets; i++ {
+		data[fmt.Sprintf("target%d", i)] = benchmarkDeepChilds(targetDepth-1, extraSiblings)
+	}
+	for j := 0; j < extraFields; j++ {
+		data[fmt.Sprintf("extra%d", j)] = benchmarkDeepChilds(targetDepth-1, extraSiblings)
+	}
+	// create the target list
+	for i := 0; i < numTargets; i++ {
+		var buffer bytes.Buffer
+		buffer.WriteString(fmt.Sprintf("target%d", i))
+		for j := targetDepth - 1; j >= 0; j-- {
+			buffer.WriteString(fmt.Sprintf(".child%d", j))
+		}
+		target_keys[i] = buffer.String()
+	}
+	return data, target_keys
+}
+
+func BenchmarkEntityFormatter_deepWhitelistingFilter(b *testing.B) {
+	numTargets := []int{0, 1, 2, 5, 10}
+	depths := []int{1, 3, 7}
+	for _, nTargets := range numTargets {
+		for _, depth := range depths {
+			extraFields := nTargets + depth*2
+			extraSiblings := nTargets
+			data, whitelist := benchmarkDeepStructure(nTargets, depth, extraFields, extraSiblings)
+			sample := Response{
+				Data:       data,
+				IsComplete: true,
+			}
+			f := NewEntityFormatter("", whitelist, []string{}, "", map[string]string{})
+			b.Run(fmt.Sprintf("numTargets:%d,depth:%d,extraFields:%d,extraSiblings:%d", nTargets, depth, extraFields, extraSiblings), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					f.Format(sample)
+				}
+			})
+		}
+	}
 }
 
 func BenchmarkEntityFormatter_blacklistingFilter(b *testing.B) {

--- a/proxy/formatter_test.go
+++ b/proxy/formatter_test.go
@@ -63,7 +63,7 @@ func TestEntityFormatter_newWhitelistingFilter(t *testing.T) {
 	}
 }
 
-func TestEntityFormatter_newWhitelistingFilterKeyOrder(t *testing.T) {
+func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 	sample := Response{
 		Data: map[string]interface{}{
 			"id": 42,
@@ -71,6 +71,9 @@ func TestEntityFormatter_newWhitelistingFilterKeyOrder(t *testing.T) {
 				"muku": map[string]interface{}{
 					"supu": 1,
 					"muku": 2,
+                    "gutu": map[string]interface{} {
+                        "kugu" : 42,
+                    },
 				},
 				"supu": map[string]interface{}{
 					"supu": 3,
@@ -83,10 +86,12 @@ func TestEntityFormatter_newWhitelistingFilterKeyOrder(t *testing.T) {
 	expected_supu_child := 1
 
 	var ok bool
-	f := NewEntityFormatter("", []string{"tupu.muku.supu"}, []string{}, "", map[string]string{})
+	f := NewEntityFormatter("", []string{"tupu.muku.supu", "tupu.muku.gutu.kugu"}, []string{}, "", map[string]string{})
 	res := f.Format(sample)
 	var tupu map[string]interface{}
 	var muku map[string]interface{}
+    var gutu map[string]interface{}
+    var kugu int
 	var supu_child int
 	if tupu, ok = res.Data["tupu"].(map[string]interface{}); !ok {
 		t.Errorf("The formatter does not have field tupu\n")
@@ -100,6 +105,15 @@ func TestEntityFormatter_newWhitelistingFilterKeyOrder(t *testing.T) {
 	if _, ok = tupu["supu"].(map[string]interface{}); ok {
 		t.Errorf("The formatter should have removed tupu.supu\n")
 	}
+    if _, ok = muku["muku"]; ok {
+		t.Errorf("The formatter should have removed tupu.muku.muku\n")
+    }
+    if gutu, ok = muku["gutu"].(map[string]interface{}); !ok {
+		t.Errorf("The formatter does not have field tupu.muku.gutu\n")
+    }
+    if kugu, ok = gutu["kugu"].(int); !ok || kugu != 42 {
+		t.Errorf("The formatter does not have field tupu.muku.gutu.kugu\n")
+    }
 }
 
 func TestEntityFormatter_newblacklistingFilter(t *testing.T) {

--- a/proxy/formatter_test.go
+++ b/proxy/formatter_test.go
@@ -63,6 +63,45 @@ func TestEntityFormatter_newWhitelistingFilter(t *testing.T) {
 	}
 }
 
+func TestEntityFormatter_newWhitelistingFilterKeyOrder(t *testing.T) {
+	sample := Response{
+		Data: map[string]interface{}{
+			"id": 42,
+			"tupu": map[string]interface{}{
+				"muku": map[string]interface{}{
+					"supu": 1,
+					"muku": 2,
+				},
+				"supu": map[string]interface{}{
+					"supu": 3,
+					"muku": 4,
+				},
+			},
+		},
+		IsComplete: true,
+	}
+	expected_supu_child := 1
+
+	var ok bool
+	f := NewEntityFormatter("", []string{"tupu.muku.supu"}, []string{}, "", map[string]string{})
+	res := f.Format(sample)
+	var tupu map[string]interface{}
+	var muku map[string]interface{}
+	var supu_child int
+	if tupu, ok = res.Data["tupu"].(map[string]interface{}); !ok {
+		t.Errorf("The formatter does not have field tupu\n")
+	}
+	if muku, ok = tupu["muku"].(map[string]interface{}); !ok {
+		t.Errorf("The formatter does not have field tupu.muku\n")
+	}
+	if supu_child, ok = muku["supu"].(int); !ok || supu_child != expected_supu_child {
+		t.Errorf("The formatter does not have field tupu.muku.supu or wrong value\n")
+	}
+	if _, ok = tupu["supu"].(map[string]interface{}); ok {
+		t.Errorf("The formatter should have removed tupu.supu\n")
+	}
+}
+
 func TestEntityFormatter_newblacklistingFilter(t *testing.T) {
 	sample := Response{
 		Data: map[string]interface{}{

--- a/proxy/formatter_test.go
+++ b/proxy/formatter_test.go
@@ -83,7 +83,7 @@ func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 		},
 		IsComplete: true,
 	}
-	expected_supu_child := 1
+	expectedSupuChild := 1
 
 	var ok bool
 	f := NewEntityFormatter("", []string{"tupu.muku.supu", "tupu.muku.gutu.kugu"}, []string{}, "", map[string]string{})
@@ -92,14 +92,14 @@ func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 	var muku map[string]interface{}
 	var gutu map[string]interface{}
 	var kugu int
-	var supu_child int
+	var supuChild int
 	if tupu, ok = res.Data["tupu"].(map[string]interface{}); !ok {
 		t.Errorf("The formatter does not have field tupu\n")
 	}
 	if muku, ok = tupu["muku"].(map[string]interface{}); !ok {
 		t.Errorf("The formatter does not have field tupu.muku\n")
 	}
-	if supu_child, ok = muku["supu"].(int); !ok || supu_child != expected_supu_child {
+	if supuChild, ok = muku["supu"].(int); !ok || supuChild != expectedSupuChild {
 		t.Errorf("The formatter does not have field tupu.muku.supu or wrong value\n")
 	}
 	if _, ok = tupu["supu"].(map[string]interface{}); ok {

--- a/proxy/formatter_test.go
+++ b/proxy/formatter_test.go
@@ -71,9 +71,9 @@ func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 				"muku": map[string]interface{}{
 					"supu": 1,
 					"muku": 2,
-                    "gutu": map[string]interface{} {
-                        "kugu" : 42,
-                    },
+					"gutu": map[string]interface{}{
+						"kugu": 42,
+					},
 				},
 				"supu": map[string]interface{}{
 					"supu": 3,
@@ -90,8 +90,8 @@ func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 	res := f.Format(sample)
 	var tupu map[string]interface{}
 	var muku map[string]interface{}
-    var gutu map[string]interface{}
-    var kugu int
+	var gutu map[string]interface{}
+	var kugu int
 	var supu_child int
 	if tupu, ok = res.Data["tupu"].(map[string]interface{}); !ok {
 		t.Errorf("The formatter does not have field tupu\n")
@@ -105,15 +105,15 @@ func TestEntityFormatter_newWhitelistingDeepFields(t *testing.T) {
 	if _, ok = tupu["supu"].(map[string]interface{}); ok {
 		t.Errorf("The formatter should have removed tupu.supu\n")
 	}
-    if _, ok = muku["muku"]; ok {
+	if _, ok = muku["muku"]; ok {
 		t.Errorf("The formatter should have removed tupu.muku.muku\n")
-    }
-    if gutu, ok = muku["gutu"].(map[string]interface{}); !ok {
+	}
+	if gutu, ok = muku["gutu"].(map[string]interface{}); !ok {
 		t.Errorf("The formatter does not have field tupu.muku.gutu\n")
-    }
-    if kugu, ok = gutu["kugu"].(int); !ok || kugu != 42 {
+	}
+	if kugu, ok = gutu["kugu"].(int); !ok || kugu != 42 {
 		t.Errorf("The formatter does not have field tupu.muku.gutu.kugu\n")
-    }
+	}
 }
 
 func TestEntityFormatter_newblacklistingFilter(t *testing.T) {


### PR DESCRIPTION
I found that current whitelist only allows two level depth, but I like to be able to select more in depth fields.

So I tried this change, that while using up to two level depth whitelist, it keeps running at similar speed / performance that was with previous code, but allows to select any deeper level fields.

(Removed implementation details comment part that no longer apply)

