### PR TITLE
max idle connection per host

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ const (
 	BracketsRouterPatternBuilder = iota
 	// ColonRouterPatternBuilder use a colon as route param delimiter
 	ColonRouterPatternBuilder
+	DefaultMaxIdleConnsPerHost = 250
 )
 
 // RoutingPattern to use during route conversion. By default, use the colon router pattern
@@ -43,6 +44,8 @@ type ServiceConfig struct {
 	WriteTimeout      time.Duration
 	IdleTimeout       time.Duration
 	ReadHeaderTimeout time.Duration
+
+	MaxIdleConnsPerHost int
 
 	// run krakend in debug mode
 	Debug     bool
@@ -144,6 +147,10 @@ func (s *ServiceConfig) Init() error {
 	if s.Port == 0 {
 		s.Port = defaultPort
 	}
+	if s.MaxIdleConnsPerHost == 0 {
+		s.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	}
+
 	s.Host = s.uriParser.CleanHosts(s.Host)
 	for i, e := range s.Endpoints {
 		e.Endpoint = s.uriParser.CleanPath(e.Endpoint)

--- a/config/config.go
+++ b/config/config.go
@@ -40,12 +40,12 @@ type ServiceConfig struct {
 	// Extra configuration for customized behaviour
 	ExtraConfig ExtraConfig `mapstructure:"extra_config"`
 
-	ReadTimeout       time.Duration
-	WriteTimeout      time.Duration
-	IdleTimeout       time.Duration
-	ReadHeaderTimeout time.Duration
+	ReadTimeout       time.Duration `mapstructure:"read_timeout"`
+	WriteTimeout      time.Duration `mapstructure:"write_timeout"`
+	IdleTimeout       time.Duration `mapstructure:"idle_timeout"`
+	ReadHeaderTimeout time.Duration `mapstructure:"read_header_timeout"`
 
-	MaxIdleConnsPerHost int
+	MaxIdleConnsPerHost int `mapstructure:"max_idle_connections"`
 
 	// run krakend in debug mode
 	Debug     bool

--- a/config/parser.go
+++ b/config/parser.go
@@ -44,32 +44,34 @@ func (p parser) Parse(configFile string) (ServiceConfig, error) {
 }
 
 type parseableServiceConfig struct {
-	Endpoints         []*parseableEndpointConfig `json:"endpoints"`
-	Timeout           string                     `json:"timeout"`
-	CacheTTL          int                        `json:"cache_ttl"`
-	Host              []string                   `json:"host"`
-	Port              int                        `json:"port"`
-	Version           int                        `json:"version"`
-	ExtraConfig       *ExtraConfig               `json:"extra_config,omitempty"`
-	ReadTimeout       string                     `json:"read_timeout"`
-	WriteTimeout      string                     `json:"write_timeout"`
-	IdleTimeout       string                     `json:"idle_timeout"`
-	ReadHeaderTimeout string                     `json:"read_header_timeout"`
-	Debug             bool
+	Endpoints           []*parseableEndpointConfig `json:"endpoints"`
+	Timeout             string                     `json:"timeout"`
+	CacheTTL            int                        `json:"cache_ttl"`
+	Host                []string                   `json:"host"`
+	Port                int                        `json:"port"`
+	Version             int                        `json:"version"`
+	ExtraConfig         *ExtraConfig               `json:"extra_config,omitempty"`
+	ReadTimeout         string                     `json:"read_timeout"`
+	WriteTimeout        string                     `json:"write_timeout"`
+	IdleTimeout         string                     `json:"idle_timeout"`
+	ReadHeaderTimeout   string                     `json:"read_header_timeout"`
+	MaxIdleConnsPerHost int                        `json:"max_idle_connections"`
+	Debug               bool
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
 	cfg := ServiceConfig{
-		Timeout:           parseDuration(p.Timeout),
-		CacheTTL:          time.Duration(p.CacheTTL) * time.Second,
-		Host:              p.Host,
-		Port:              p.Port,
-		Version:           p.Version,
-		Debug:             p.Debug,
-		ReadTimeout:       parseDuration(p.ReadTimeout),
-		WriteTimeout:      parseDuration(p.WriteTimeout),
-		IdleTimeout:       parseDuration(p.IdleTimeout),
-		ReadHeaderTimeout: parseDuration(p.ReadHeaderTimeout),
+		Timeout:             parseDuration(p.Timeout),
+		CacheTTL:            time.Duration(p.CacheTTL) * time.Second,
+		Host:                p.Host,
+		Port:                p.Port,
+		Version:             p.Version,
+		Debug:               p.Debug,
+		ReadTimeout:         parseDuration(p.ReadTimeout),
+		WriteTimeout:        parseDuration(p.WriteTimeout),
+		IdleTimeout:         parseDuration(p.IdleTimeout),
+		ReadHeaderTimeout:   parseDuration(p.ReadHeaderTimeout),
+		MaxIdleConnsPerHost: p.MaxIdleConnsPerHost,
 	}
 	if p.ExtraConfig != nil {
 		cfg.ExtraConfig = *p.ExtraConfig

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -69,6 +69,8 @@ func (r ginRouter) Run(cfg config.ServiceConfig) {
 		r.cfg.Logger.Debug("Debug enabled")
 	}
 
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = cfg.MaxIdleConnsPerHost
+
 	r.cfg.Engine.RedirectTrailingSlash = true
 	r.cfg.Engine.RedirectFixedPath = true
 	r.cfg.Engine.HandleMethodNotAllowed = true

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -88,6 +88,8 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 		r.cfg.Engine.Handle(r.cfg.DebugPattern, DebugHandler(r.cfg.Logger))
 	}
 
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = cfg.MaxIdleConnsPerHost
+
 	r.registerKrakendEndpoints(cfg.Endpoints)
 
 	server := http.Server{


### PR DESCRIPTION
define the `MaxIdleConnsPerHost` param for the default http transport layer.