### PR TITLE
Fix #80: Merge incomplete responses data

### DIFF
--- a/proxy/merging_test.go
+++ b/proxy/merging_test.go
@@ -41,6 +41,39 @@ func TestNewMergeDataMiddleware_ok(t *testing.T) {
 	}
 }
 
+func TestNewMergeDataMiddleware_mergeIncompleteResults(t *testing.T) {
+	timeout := 500
+	backend := config.Backend{}
+	endpoint := config.EndpointConfig{
+		Backend: []*config.Backend{&backend, &backend},
+		Timeout: time.Duration(timeout) * time.Millisecond,
+	}
+	mw := NewMergeDataMiddleware(&endpoint)
+	p := mw(
+		dummyProxy(&Response{Data: map[string]interface{}{"supu": 42}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"tupu": true}, IsComplete: false}))
+	mustEnd := time.After(time.Duration(2*timeout) * time.Millisecond)
+	out, err := p(context.Background(), &Request{})
+	if err != nil {
+		t.Errorf("The middleware propagated an unexpected error: %s\n", err.Error())
+	}
+	if out == nil {
+		t.Errorf("The proxy returned a null result\n")
+		return
+	}
+	select {
+	case <-mustEnd:
+		t.Errorf("We were expecting a response but we got none\n")
+	default:
+		if len(out.Data) != 2 {
+			t.Errorf("We were expecting incomplete results merged but we got %v!\n", out)
+		}
+		if out.IsComplete {
+			t.Errorf("We were expecting an incomplete response but we got an incompleted one!\n")
+		}
+	}
+}
+
 func TestNewMergeDataMiddleware_partialTimeout(t *testing.T) {
 	timeout := 100
 	backend := config.Backend{Timeout: time.Duration(timeout) * time.Millisecond}


### PR DESCRIPTION
Fix https://github.com/devopsfaith/krakend/issues/80 

In commit https://github.com/devopsfaith/krakend/commit/cc67d65263ac836659a0ac190e85fa707de3fba1 there is the test that reproduces the issue, and the fix in https://github.com/devopsfaith/krakend/commit/3882217eb2dbe92ce27d7d227935285df0468217.

I've run the benchmarks, and there is also a minor improvement in speed / allocs:

Before:
```
goos: linux
goarch: amd64
pkg: krakend/proxy
BenchmarkNewMergeDataMiddleware/with_2_parts-8         	  300000	      4593 ns/op	    1360 B/op	      20 allocs/op
BenchmarkNewMergeDataMiddleware/with_3_parts-8         	  300000	      5384 ns/op	    1488 B/op	      22 allocs/op
BenchmarkNewMergeDataMiddleware/with_4_parts-8         	  200000	      5826 ns/op	    1584 B/op	      24 allocs/op
PASS
ok  	krakend/proxy	5.501s
```
After:
```
goos: linux
goarch: amd64
pkg: krakend/proxy
BenchmarkNewMergeDataMiddleware/with_2_parts-8         	  500000	      4339 ns/op	     976 B/op	      17 allocs/op
BenchmarkNewMergeDataMiddleware/with_3_parts-8         	  300000	      5154 ns/op	    1104 B/op	      19 allocs/op
BenchmarkNewMergeDataMiddleware/with_4_parts-8         	  300000	      5789 ns/op	    1200 B/op	      21 allocs/op
PASS
ok  	krakend/proxy	6.747s
```
 

