### PR TITLE
Support golang plugins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,9 @@ type ServiceConfig struct {
 	// DisableStrictREST flags if the REST enforcement is disabled
 	DisableStrictREST bool `mapstructure:"disable_rest"`
 
+	// Plugin defines the configuration for the plugin loader
+	Plugin *Plugin `mapstructure:"plugin"`
+
 	// run krakend in debug mode
 	Debug     bool
 	uriParser URIParser
@@ -123,6 +126,12 @@ type Backend struct {
 	Decoder encoding.Decoder
 	// Backend Extra configuration for customized behaviours
 	ExtraConfig ExtraConfig `mapstructure:"extra_config"`
+}
+
+// Plugin contains the config required by the plugin module
+type Plugin struct {
+	Folder  string `mapstructure:"folder"`
+	Pattern string `mapstructure:"pattern"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/parser.go
+++ b/config/parser.go
@@ -32,10 +32,10 @@ func (p parser) Parse(configFile string) (ServiceConfig, error) {
 	var cfg parseableServiceConfig
 	data, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return result, fmt.Errorf("Fatal error config file: %s \n", configFile)
+		return result, fmt.Errorf("Fatal error config file: %s", configFile)
 	}
 	if err = json.Unmarshal(data, &cfg); err != nil {
-		return result, fmt.Errorf("Fatal error config file: While parsing config: %s \n", err.Error())
+		return result, fmt.Errorf("Fatal error config file: While parsing config: %s", err.Error())
 	}
 	result = cfg.normalize()
 	err = result.Init()
@@ -57,6 +57,7 @@ type parseableServiceConfig struct {
 	ReadHeaderTimeout   string                     `json:"read_header_timeout"`
 	MaxIdleConnsPerHost int                        `json:"max_idle_connections"`
 	Debug               bool
+	Plugin              *Plugin
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
@@ -72,6 +73,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 		IdleTimeout:         parseDuration(p.IdleTimeout),
 		ReadHeaderTimeout:   parseDuration(p.ReadHeaderTimeout),
 		MaxIdleConnsPerHost: p.MaxIdleConnsPerHost,
+		Plugin:              p.Plugin,
 	}
 	if p.ExtraConfig != nil {
 		cfg.ExtraConfig = *p.ExtraConfig

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -62,14 +62,18 @@ func open(pluginName string) (err error) {
 			}
 		}
 	}()
-	_, err = plugin.Open(pluginName)
+	_, err = pluginOpener(pluginName)
 	return
 }
+
+// pluginOpener keeps the plugin open function in a var for easy testing
+var pluginOpener = plugin.Open
 
 type loaderError struct {
 	errors []error
 }
 
+// Error implements the error interface
 func (l loaderError) Error() string {
 	msgs := make([]string, len(l.errors))
 	for i, err := range l.errors {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -39,7 +39,7 @@ func load(plugins []string) (int, error) {
 	errors := []error{}
 	loadedPlugins := 0
 	for k, pluginName := range plugins {
-		if _, err := plugin.Open(pluginName); err != nil {
+		if err := open(pluginName); err != nil {
 			errors = append(errors, fmt.Errorf("opening plugin %d (%s): %s", k, pluginName, err.Error()))
 			continue
 		}
@@ -50,6 +50,20 @@ func load(plugins []string) (int, error) {
 		return loadedPlugins, loaderError{errors}
 	}
 	return loadedPlugins, nil
+}
+
+func open(pluginName string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			err, ok = r.(error)
+			if !ok {
+				err = fmt.Errorf("%v", r)
+			}
+		}
+	}()
+	_, err = plugin.Open(pluginName)
+	return
 }
 
 type loaderError struct {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"fmt"
+	"io/ioutil"
+	"plugin"
+	"strings"
+)
+
+// Load loads all the plugins in pluginFolder with pattern in its filename.
+// It returns the number of plugins loaded and an error if something goes wrong.
+func Load(pluginFolder, pattern string) (int, error) {
+	plugins, err := scan(pluginFolder, pattern)
+	if err != nil {
+		return 0, err
+	}
+	return load(plugins)
+}
+
+func scan(folder, pattern string) ([]string, error) {
+	files, err := ioutil.ReadDir(folder)
+	if err != nil {
+		return []string{}, err
+	}
+
+	plugins := []string{}
+	for _, file := range files {
+		if !file.IsDir() && strings.Contains(file.Name(), pattern) {
+			plugins = append(plugins, folder+file.Name())
+		}
+	}
+
+	return plugins, nil
+}
+
+func load(plugins []string) (int, error) {
+	errors := []error{}
+	loadedPlugins := 0
+	for k, pluginName := range plugins {
+		if _, err := plugin.Open(pluginName); err != nil {
+			errors = append(errors, fmt.Errorf("opening plugin %d (%s): %s", k, pluginName, err.Error()))
+			continue
+		}
+		loadedPlugins++
+	}
+
+	if len(errors) > 0 {
+		return loadedPlugins, loaderError{errors}
+	}
+	return loadedPlugins, nil
+}
+
+type loaderError struct {
+	errors []error
+}
+
+func (l loaderError) Error() string {
+	msgs := make([]string, len(l.errors))
+	for i, err := range l.errors {
+		msgs[i] = err.Error()
+	}
+	return fmt.Sprintf("plugin loader found %d error(s): \n%s", len(msgs), strings.Join(msgs, "\n"))
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -5,12 +5,14 @@ import (
 	"io/ioutil"
 	"plugin"
 	"strings"
+
+	"github.com/devopsfaith/krakend/config"
 )
 
 // Load loads all the plugins in pluginFolder with pattern in its filename.
 // It returns the number of plugins loaded and an error if something goes wrong.
-func Load(pluginFolder, pattern string) (int, error) {
-	plugins, err := scan(pluginFolder, pattern)
+func Load(cfg config.Plugin) (int, error) {
+	plugins, err := scan(cfg.Folder, cfg.Pattern)
 	if err != nil {
 		return 0, err
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"io/ioutil"
 	"os"
+	"plugin"
 	"testing"
 
 	"github.com/devopsfaith/krakend/config"
@@ -63,6 +64,39 @@ func TestLoad_noMatches(t *testing.T) {
 }
 
 func TestLoad_erroredLoad(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(".", "test")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	f, err := ioutil.TempFile(tmpDir, "test.so")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	f.Close()
+	defer os.RemoveAll(tmpDir)
+	tot, err := Load(config.Plugin{Folder: tmpDir, Pattern: ".so"})
+	if tot != 0 {
+		t.Error("unexpected number of plugins loaded:", tot)
+	}
+	if err == nil {
+		t.Error("expecting error!")
+		return
+	}
+	if err.Error()[:55] != "plugin loader found 1 error(s): \nopening plugin 0 (test" {
+		t.Error("unexpected error:", err.Error()[:55])
+	}
+}
+
+func TestLoad_panicRecovered(t *testing.T) {
+	intialPOValue := pluginOpener
+	pluginOpener = func(path string) (*plugin.Plugin, error) {
+		panic("recover this, please")
+		return nil, nil
+	}
+	defer func() { pluginOpener = intialPOValue }()
 	tmpDir, err := ioutil.TempDir(".", "test")
 	if err != nil {
 		t.Error("unexpected error:", err.Error())

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -4,11 +4,13 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/devopsfaith/krakend/config"
 )
 
 func TestLoad_noFolder(t *testing.T) {
 	expectedErr := "open unknown: no such file or directory"
-	tot, err := Load("unknown", "")
+	tot, err := Load(config.Plugin{Folder: "unknown", Pattern: ""})
 	if tot != 0 {
 		t.Error("unexpected number of plugins loaded:", tot)
 	}
@@ -27,7 +29,7 @@ func TestLoad_emptyFolder(t *testing.T) {
 		t.Error("unexpected error:", err.Error())
 		return
 	}
-	tot, err := Load(name, "")
+	tot, err := Load(config.Plugin{Folder: name, Pattern: ""})
 	if tot != 0 {
 		t.Error("unexpected number of plugins loaded:", tot)
 	}
@@ -51,7 +53,7 @@ func TestLoad_noMatches(t *testing.T) {
 	}
 	f.Close()
 	defer os.RemoveAll(tmpDir)
-	tot, err := Load(tmpDir, ".so")
+	tot, err := Load(config.Plugin{Folder: tmpDir, Pattern: ".so"})
 	if tot != 0 {
 		t.Error("unexpected number of plugins loaded:", tot)
 	}
@@ -74,7 +76,7 @@ func TestLoad_erroredLoad(t *testing.T) {
 	}
 	f.Close()
 	defer os.RemoveAll(tmpDir)
-	tot, err := Load(tmpDir, ".so")
+	tot, err := Load(config.Plugin{Folder: tmpDir, Pattern: ".so"})
 	if tot != 0 {
 		t.Error("unexpected number of plugins loaded:", tot)
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLoad_noFolder(t *testing.T) {
+	expectedErr := "open unknown: no such file or directory"
+	tot, err := Load("unknown", "")
+	if tot != 0 {
+		t.Error("unexpected number of plugins loaded:", tot)
+	}
+	if err == nil {
+		t.Error("expecting error!")
+		return
+	}
+	if err.Error() != expectedErr {
+		t.Error("unexpected error:", err.Error())
+	}
+}
+
+func TestLoad_emptyFolder(t *testing.T) {
+	name, err := ioutil.TempDir(".", "test")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	tot, err := Load(name, "")
+	if tot != 0 {
+		t.Error("unexpected number of plugins loaded:", tot)
+	}
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+	}
+	os.RemoveAll(name)
+}
+
+func TestLoad_noMatches(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(".", "test")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	f, err := ioutil.TempFile(tmpDir, "test")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	f.Close()
+	defer os.RemoveAll(tmpDir)
+	tot, err := Load(tmpDir, ".so")
+	if tot != 0 {
+		t.Error("unexpected number of plugins loaded:", tot)
+	}
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+	}
+}
+
+func TestLoad_erroredLoad(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(".", "test")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+	f, err := ioutil.TempFile(tmpDir, "test.so")
+	if err != nil {
+		t.Error("unexpected error:", err.Error())
+		return
+	}
+	f.Close()
+	defer os.RemoveAll(tmpDir)
+	tot, err := Load(tmpDir, ".so")
+	if tot != 0 {
+		t.Error("unexpected number of plugins loaded:", tot)
+	}
+	if err == nil {
+		t.Error("expecting error!")
+		return
+	}
+	if err.Error()[:55] != "plugin loader found 1 error(s): \nopening plugin 0 (test" {
+		t.Error("unexpected error:", err.Error()[:55])
+	}
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -94,7 +94,6 @@ func TestLoad_panicRecovered(t *testing.T) {
 	intialPOValue := pluginOpener
 	pluginOpener = func(path string) (*plugin.Plugin, error) {
 		panic("recover this, please")
-		return nil, nil
 	}
 	defer func() { pluginOpener = intialPOValue }()
 	tmpDir, err := ioutil.TempDir(".", "test")


### PR DESCRIPTION
this PR adds an initial implementation of a simple plugin loader.

at this early stage, plugins are responsible for registering and kicking off their own components.

a very nice plugin candidate could be a set of martian modifiers, because they already register themselves into the martian register and users can include the new types in their martian DSL without recompiling the KrakenD binary

**I'd like to remark the experimental status of this language feature, so use with caution**