### PR TITLE
combiner register added

### DIFF
--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/devopsfaith/krakend/config"
@@ -17,6 +18,7 @@ func NewMergeDataMiddleware(endpointConfig *config.EndpointConfig) Middleware {
 		return EmptyMiddleware
 	}
 	serviceTimeout := time.Duration(85*endpointConfig.Timeout.Nanoseconds()/100) * time.Nanosecond
+	combiner := getResponseCombiner(endpointConfig.ExtraConfig)
 
 	return func(next ...Proxy) Proxy {
 		if len(next) != totalBackends {
@@ -48,7 +50,7 @@ func NewMergeDataMiddleware(endpointConfig *config.EndpointConfig) Middleware {
 				return &Response{Data: make(map[string]interface{}), IsComplete: false}, err
 			}
 
-			result := combineData(totalBackends, responses)
+			result := combiner(localCtx, totalBackends, responses)
 			cancel()
 			return result, err
 		}
@@ -77,7 +79,45 @@ func requestPart(ctx context.Context, next Proxy, request *Request, out chan<- *
 	cancel()
 }
 
-func combineData(total int, parts []*Response) *Response {
+// ResponseCombiner func to merge the collected responses into a single one
+type ResponseCombiner func(context.Context, int, []*Response) *Response
+
+// RegisterResponseCombiner adds a new response combiner into the internal register
+func RegisterResponseCombiner(name string, f ResponseCombiner) {
+	responseCombinersMutex.Lock()
+	responseCombiners[name] = f
+	responseCombinersMutex.Unlock()
+}
+
+const (
+	mergeKey            = "combiner"
+	defaultCombinerName = "default"
+)
+
+var (
+	responseCombinersMutex = &sync.RWMutex{}
+	responseCombiners      = map[string]ResponseCombiner{
+		defaultCombinerName: combineData,
+	}
+)
+
+func getResponseCombiner(extra config.ExtraConfig) ResponseCombiner {
+	responseCombinersMutex.RLock()
+	combiner := responseCombiners[defaultCombinerName]
+	if v, ok := extra[Namespace]; ok {
+		if e, ok := v.(map[string]interface{}); ok {
+			if v, ok := e[mergeKey]; ok {
+				if c, ok := responseCombiners[v.(string)]; ok {
+					combiner = c
+				}
+			}
+		}
+	}
+	responseCombinersMutex.RUnlock()
+	return combiner
+}
+
+func combineData(_ context.Context, total int, parts []*Response) *Response {
 	isComplete := len(parts) == total
 	var retResponse *Response
 	for _, part := range parts {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -9,6 +9,9 @@ import (
 	"github.com/devopsfaith/krakend/config"
 )
 
+// Namespace to be used in extra config
+const Namespace = "github.com/devopsfaith/krakend/proxy"
+
 // Metadata is the Metadata of the Response which contains Headers and StatusCode
 type Metadata struct {
 	Headers    map[string][]string


### PR DESCRIPTION
as requested in #78 , this PR adds a register for easy injection of custom combiners without changing the proxy (pipe) factory but the endpoint config