### PR TITLE
Fix for readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A ready to use example:
             serviceConfig.Port = *port
         }
 
-        logger := logging.NewLogger(*logLevel, os.Stdout, "[KRAKEND]")
+        logger, _ := logging.NewLogger(*logLevel, os.Stdout, "[KRAKEND]")
 
         routerFactory := gin.DefaultFactory(proxy.DefaultFactory(logger), logger)
 


### PR DESCRIPTION
Quick fix for `multiple-value logging.NewLogger() in single-value context` error in the README example. 
Simplified, though - swallowing the invalid level error.