### PR TITLE
Inject registers to plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
     - "1.10"
     - 1.9
+    - 1.8
 
 script:
     - make prepare coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
     - "1.10"
     - 1.9
-    - 1.8
 
 script:
     - make prepare coveralls

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ deps:
 	@echo ""
 
 test:
-	go fmt ./...
-	go test -v -cover ./...
+	go test -cover ./...
 
 benchmark:
 	@echo "Proxy middleware stack"

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -20,10 +20,10 @@ import (
 type Decoder func(io.Reader, *map[string]interface{}) error
 
 // A DecoderFactory is a function that returns CollectionDecoder or an EntityDecoder
-type DecoderFactory func(bool) Decoder
+type DecoderFactory func(bool) func(io.Reader, *map[string]interface{}) error
 
 // Deprecated: Register is deprecated
-func Register(name string, dec DecoderFactory) error {
+func Register(name string, dec func(bool) func(io.Reader, *map[string]interface{}) error) error {
 	return decoders.Register(name, dec)
 }
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -11,9 +11,7 @@ Decode decodes HTTP responses:
 */
 package encoding
 
-import (
-	"io"
-)
+import "io"
 
 // A Decoder is a function that reads from the reader and decodes it
 // into an map of interfaces

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -11,7 +11,9 @@ Decode decodes HTTP responses:
 */
 package encoding
 
-import "io"
+import (
+	"io"
+)
 
 // A Decoder is a function that reads from the reader and decodes it
 // into an map of interfaces
@@ -20,24 +22,12 @@ type Decoder func(io.Reader, *map[string]interface{}) error
 // A DecoderFactory is a function that returns CollectionDecoder or an EntityDecoder
 type DecoderFactory func(bool) Decoder
 
-var decoders = map[string]DecoderFactory{
-	JSON:   NewJSONDecoder,
-	STRING: NewStringDecoder,
-}
-
-// Register registers the decoder factory with the given name
+// Deprecated: Register is deprecated
 func Register(name string, dec DecoderFactory) error {
-	decoders[name] = dec
-	return nil
+	return decoders.Register(name, dec)
 }
 
-// Get returns (from the register) the decoder factory by name. If there is no factory with the received name
-// it returns the JSON decoder factory
+// Deprecated: Get is deprecated
 func Get(name string) DecoderFactory {
-	for _, n := range []string{name, JSON} {
-		if dec, ok := decoders[n]; ok {
-			return dec
-		}
-	}
-	return NewJSONDecoder
+	return decoders.Get(name)
 }

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -2,25 +2,23 @@ package encoding
 
 import (
 	"strings"
-	"sync"
 	"testing"
+
+	"github.com/devopsfaith/krakend/register"
 )
 
 func TestRegister(t *testing.T) {
 	original := decoders
 
-	if len(decoders.data) != 2 {
-		t.Error("Unexpected number of registered factories:", len(decoders.data))
+	if len(decoders.data.Clone()) != 2 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 
-	decoders = &DecoderRegister{
-		data:  map[string]DecoderFactory{},
-		mutex: &sync.RWMutex{},
-	}
+	decoders = &DecoderRegister{register.NewUntyped()}
 	Register("some", NewJSONDecoder)
 
-	if len(decoders.data) != 1 {
-		t.Error("Unexpected number of registered factories:", len(decoders.data))
+	if len(decoders.data.Clone()) != 1 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 
 	decoders = original
@@ -29,21 +27,18 @@ func TestRegister(t *testing.T) {
 func TestGet(t *testing.T) {
 	original := decoders
 
-	if len(decoders.data) != 2 {
-		t.Error("Unexpected number of registered factories:", len(decoders.data))
+	if len(decoders.data.Clone()) != 2 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 
 	checkDecoder(t, JSON)
 	checkDecoder(t, "some")
 
-	decoders = &DecoderRegister{
-		data:  map[string]DecoderFactory{},
-		mutex: &sync.RWMutex{},
-	}
+	decoders = &DecoderRegister{register.NewUntyped()}
 	Register("some", NewJSONDecoder)
 
-	if len(decoders.data) != 1 {
-		t.Error("Unexpected number of registered factories:", len(decoders.data))
+	if len(decoders.data.Clone()) != 1 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 
 	checkDecoder(t, JSON)

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	original := decoders
+	original := GetRegister()
 
-	if len(decoders.data.Clone()) != 2 {
-		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
+	if len(original.data.Clone()) != 2 {
+		t.Error("Unexpected number of registered factories:", len(original.data.Clone()))
 	}
 
 	decoders = &DecoderRegister{register.NewUntyped()}
@@ -21,12 +21,10 @@ func TestRegister(t *testing.T) {
 		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 
-	decoders = original
+	decoders = initDecoderRegister()
 }
 
 func TestGet(t *testing.T) {
-	original := decoders
-
 	if len(decoders.data.Clone()) != 2 {
 		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
@@ -44,7 +42,7 @@ func TestGet(t *testing.T) {
 	checkDecoder(t, JSON)
 	checkDecoder(t, "some")
 
-	decoders = original
+	decoders = initDecoderRegister()
 }
 
 func checkDecoder(t *testing.T, name string) {

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -1,6 +1,9 @@
 package encoding
 
 import (
+	"errors"
+	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -8,6 +11,9 @@ import (
 )
 
 func TestRegister(t *testing.T) {
+	decoders = initDecoderRegister()
+	defer func() { decoders = initDecoderRegister() }()
+
 	original := GetRegister()
 
 	if len(original.data.Clone()) != 2 {
@@ -20,11 +26,12 @@ func TestRegister(t *testing.T) {
 	if len(decoders.data.Clone()) != 1 {
 		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
-
-	decoders = initDecoderRegister()
 }
 
 func TestGet(t *testing.T) {
+	decoders = initDecoderRegister()
+	defer func() { decoders = initDecoderRegister() }()
+
 	if len(decoders.data.Clone()) != 2 {
 		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
@@ -41,8 +48,80 @@ func TestGet(t *testing.T) {
 
 	checkDecoder(t, JSON)
 	checkDecoder(t, "some")
+}
 
+func TestRegister_complete_ok(t *testing.T) {
 	decoders = initDecoderRegister()
+	defer func() { decoders = initDecoderRegister() }()
+
+	expectedMsg := "a custom message to decode"
+	expectedResponse := map[string]interface{}{"a": 42}
+
+	if err := Register("custom", func(_ bool) func(io.Reader, *map[string]interface{}) error {
+		return func(r io.Reader, v *map[string]interface{}) error {
+			d, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Error(err)
+				return err
+			}
+			if expectedMsg != string(d) {
+				t.Errorf("unexpected msg: %s", string(d))
+				return errors.New("unexpected msg to decode")
+			}
+			*v = expectedResponse
+			return nil
+		}
+	}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	decoder := Get("custom")(false)
+	input := strings.NewReader(expectedMsg)
+	var result map[string]interface{}
+	if err := decoder(input, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if v, ok := result["a"]; !ok || v.(int) != 42 {
+		t.Error("Unexpected value:", result)
+	}
+}
+
+func TestRegister_complete_ko(t *testing.T) {
+	decoders = initDecoderRegister()
+	defer func() { decoders = initDecoderRegister() }()
+
+	expectedMsg := "a custom message to decode"
+	expectedErr := errors.New("expect me")
+
+	if err := Register("custom", func(_ bool) func(io.Reader, *map[string]interface{}) error {
+		return func(r io.Reader, v *map[string]interface{}) error {
+			d, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Error(err)
+				return err
+			}
+			if expectedMsg != string(d) {
+				t.Errorf("unexpected msg: %s", string(d))
+				return errors.New("unexpected msg to decode")
+			}
+			v = nil
+			return expectedErr
+		}
+	}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	decoder := Get("custom")(false)
+	input := strings.NewReader(expectedMsg)
+	var result map[string]interface{}
+	if err := decoder(input, &result); err != expectedErr {
+		t.Error("Unexpected error:", err)
+	}
+	if result != nil {
+		t.Error("Unexpected value:", result)
+	}
 }
 
 func checkDecoder(t *testing.T, name string) {

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -2,21 +2,25 @@ package encoding
 
 import (
 	"strings"
+	"sync"
 	"testing"
 )
 
 func TestRegister(t *testing.T) {
 	original := decoders
 
-	if len(decoders) != 2 {
-		t.Error("Unexpected number of registered factories:", len(decoders))
+	if len(decoders.data) != 2 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data))
 	}
 
-	decoders = map[string]DecoderFactory{}
+	decoders = &DecoderRegister{
+		data:  map[string]DecoderFactory{},
+		mutex: &sync.RWMutex{},
+	}
 	Register("some", NewJSONDecoder)
 
-	if len(decoders) != 1 {
-		t.Error("Unexpected number of registered factories:", len(decoders))
+	if len(decoders.data) != 1 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data))
 	}
 
 	decoders = original
@@ -25,18 +29,21 @@ func TestRegister(t *testing.T) {
 func TestGet(t *testing.T) {
 	original := decoders
 
-	if len(decoders) != 2 {
-		t.Error("Unexpected number of registered factories:", len(decoders))
+	if len(decoders.data) != 2 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data))
 	}
 
 	checkDecoder(t, JSON)
 	checkDecoder(t, "some")
 
-	decoders = map[string]DecoderFactory{}
+	decoders = &DecoderRegister{
+		data:  map[string]DecoderFactory{},
+		mutex: &sync.RWMutex{},
+	}
 	Register("some", NewJSONDecoder)
 
-	if len(decoders) != 1 {
-		t.Error("Unexpected number of registered factories:", len(decoders))
+	if len(decoders.data) != 1 {
+		t.Error("Unexpected number of registered factories:", len(decoders.data))
 	}
 
 	checkDecoder(t, JSON)

--- a/encoding/json.go
+++ b/encoding/json.go
@@ -9,7 +9,7 @@ import (
 const JSON = "json"
 
 // NewJSONDecoder return the right JSON decoder
-func NewJSONDecoder(isCollection bool) Decoder {
+func NewJSONDecoder(isCollection bool) func(io.Reader, *map[string]interface{}) error {
 	if isCollection {
 		return JSONCollectionDecoder
 	}

--- a/encoding/register.go
+++ b/encoding/register.go
@@ -1,0 +1,50 @@
+package encoding
+
+import "sync"
+
+// RegisterSetter registers the decoder factory with the given name
+type RegisterSetter interface {
+	Register(name string, dec DecoderFactory) error
+}
+
+// RegisterGetter returns the decoder factory by name. If there is no factory with the received name
+// it returns the JSON decoder factory
+type RegisterGetter interface {
+	Get(name string) DecoderFactory
+}
+
+// GetRegister returns the package register
+func GetRegister() *DecoderRegister {
+	return decoders
+}
+
+var decoders = &DecoderRegister{
+	data: map[string]DecoderFactory{
+		JSON:   NewJSONDecoder,
+		STRING: NewStringDecoder,
+	},
+	mutex: &sync.RWMutex{},
+}
+
+type DecoderRegister struct {
+	data  map[string]DecoderFactory
+	mutex *sync.RWMutex
+}
+
+// Register implements the RegisterSetter interface
+func (r *DecoderRegister) Register(name string, dec DecoderFactory) error {
+	r.mutex.Lock()
+	r.data[name] = dec
+	r.mutex.Unlock()
+	return nil
+}
+
+// Get implements the RegisterGetter interface
+func (r *DecoderRegister) Get(name string) DecoderFactory {
+	for _, n := range []string{name, JSON} {
+		if dec, ok := r.data[n]; ok {
+			return dec
+		}
+	}
+	return NewJSONDecoder
+}

--- a/encoding/register.go
+++ b/encoding/register.go
@@ -1,17 +1,10 @@
 package encoding
 
-import "github.com/devopsfaith/krakend/register"
+import (
+	"io"
 
-// RegisterSetter registers the decoder factory with the given name
-type RegisterSetter interface {
-	Register(name string, dec DecoderFactory) error
-}
-
-// RegisterGetter returns the decoder factory by name. If there is no factory with the received name
-// it returns the JSON decoder factory
-type RegisterGetter interface {
-	Get(name string) DecoderFactory
-}
+	"github.com/devopsfaith/krakend/register"
+)
 
 // GetRegister returns the package register
 func GetRegister() *DecoderRegister {
@@ -24,13 +17,13 @@ type DecoderRegister struct {
 }
 
 // Register implements the RegisterSetter interface
-func (r *DecoderRegister) Register(name string, dec DecoderFactory) error {
+func (r *DecoderRegister) Register(name string, dec func(bool) func(io.Reader, *map[string]interface{}) error) error {
 	r.data.Register(name, dec)
 	return nil
 }
 
 // Get implements the RegisterGetter interface
-func (r *DecoderRegister) Get(name string) DecoderFactory {
+func (r *DecoderRegister) Get(name string) func(bool) func(io.Reader, *map[string]interface{}) error {
 	for _, n := range []string{name, JSON} {
 		if v, ok := r.data.Get(n); ok {
 			if dec, ok := v.(DecoderFactory); ok {

--- a/encoding/register.go
+++ b/encoding/register.go
@@ -26,7 +26,7 @@ func (r *DecoderRegister) Register(name string, dec func(bool) func(io.Reader, *
 func (r *DecoderRegister) Get(name string) func(bool) func(io.Reader, *map[string]interface{}) error {
 	for _, n := range []string{name, JSON} {
 		if v, ok := r.data.Get(n); ok {
-			if dec, ok := v.(DecoderFactory); ok {
+			if dec, ok := v.(func(bool) func(io.Reader, *map[string]interface{}) error); ok {
 				return dec
 			}
 		}

--- a/encoding/string.go
+++ b/encoding/string.go
@@ -9,7 +9,7 @@ import (
 const STRING = "string"
 
 // NewStringDecoder return a String decoder
-func NewStringDecoder(_ bool) Decoder {
+func NewStringDecoder(_ bool) func(io.Reader, *map[string]interface{}) error {
 	return StringDecoder
 }
 

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -1,0 +1,78 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/devopsfaith/krakend/encoding"
+	"github.com/devopsfaith/krakend/register"
+	"github.com/devopsfaith/krakend/sd"
+)
+
+// REGISTRABLE_VAR is the name to lookup after loading the plugin for the module registering
+const REGISTRABLE_VAR = "Registrable"
+
+// Register contains all the registers required by the framework and the external modules
+type Register struct {
+	Decoder  *encoding.DecoderRegister
+	SD       *sd.Register
+	External *register.Namespaced
+}
+
+// NewRegister returns a new register to be used by the plugin loader
+func NewRegister() *Register {
+	return &Register{
+		Decoder:  encoding.GetRegister(),
+		SD:       sd.GetRegister(),
+		External: register.New(),
+	}
+}
+
+// Register registers the received plugin in the propper internal registers
+func (r *Register) Register(p Plugin) error {
+	x, err := p.Lookup(REGISTRABLE_VAR)
+	if err != nil {
+		fmt.Println("unable to find the registrable symbol:", err.Error())
+		return err
+	}
+
+	totalRegistrations := 0
+
+	if registrable, ok := x.(RegistrableDecoder); ok {
+		err = registrable.RegisterDecoder(r.Decoder)
+		totalRegistrations++
+	}
+
+	if registrable, ok := x.(RegistrableSD); ok {
+		err = registrable.RegisterSD(r.SD)
+		totalRegistrations++
+	}
+
+	if registrable, ok := x.(RegistrableExternal); ok {
+		err = registrable.RegisterExternal(r.External)
+		totalRegistrations++
+	}
+
+	if totalRegistrations == 0 {
+		fmt.Println("unknown registrable interface")
+	}
+
+	return nil
+}
+
+// RegistrableDecoder defines the interface the encoding plugins should implement
+// in order to be able to register themselves
+type RegistrableDecoder interface {
+	RegisterDecoder(encoding.RegisterSetter) error
+}
+
+// RegistrableSD defines the interface the SD plugins should implement
+// in order to be able to register themselves
+type RegistrableSD interface {
+	RegisterSD(sd.RegisterSetter) error
+}
+
+// RegistrableExternal defines the interface the external plugins should implement
+// in order to be able to register themselves
+type RegistrableExternal interface {
+	RegisterExternal(*register.Namespaced) error
+}

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -43,11 +43,6 @@ func (r *Register) Register(p Plugin) error {
 		totalRegistrations++
 	}
 
-	if registrable, ok := x.(RegistrableSD); ok {
-		err = registrable.RegisterSD(r.SD)
-		totalRegistrations++
-	}
-
 	if registrable, ok := x.(RegistrableExternal); ok {
 		err = registrable.RegisterExternal(r.External.Register)
 		totalRegistrations++
@@ -64,12 +59,6 @@ func (r *Register) Register(p Plugin) error {
 // in order to be able to register themselves
 type RegistrableDecoder interface {
 	RegisterDecoder(func(name string, dec func(bool) func(io.Reader, *map[string]interface{}) error) error) error
-}
-
-// RegistrableSD defines the interface the SD plugins should implement
-// in order to be able to register themselves
-type RegistrableSD interface {
-	RegisterSD(sd.RegisterSetter) error
 }
 
 // RegistrableExternal defines the interface the external plugins should implement

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -48,7 +48,7 @@ func (r *Register) Register(p Plugin) error {
 	}
 
 	if registrable, ok := x.(RegistrableExternal); ok {
-		err = registrable.RegisterExternal(r.External)
+		err = registrable.RegisterExternal(r.External.Register)
 		totalRegistrations++
 	}
 
@@ -74,5 +74,5 @@ type RegistrableSD interface {
 // RegistrableExternal defines the interface the external plugins should implement
 // in order to be able to register themselves
 type RegistrableExternal interface {
-	RegisterExternal(*register.Namespaced) error
+	RegisterExternal(func(namespace, name string, v interface{})) error
 }

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/devopsfaith/krakend/encoding"
 	"github.com/devopsfaith/krakend/register"
@@ -38,7 +39,7 @@ func (r *Register) Register(p Plugin) error {
 	totalRegistrations := 0
 
 	if registrable, ok := x.(RegistrableDecoder); ok {
-		err = registrable.RegisterDecoder(r.Decoder)
+		err = registrable.RegisterDecoder(r.Decoder.Register)
 		totalRegistrations++
 	}
 
@@ -62,7 +63,7 @@ func (r *Register) Register(p Plugin) error {
 // RegistrableDecoder defines the interface the encoding plugins should implement
 // in order to be able to register themselves
 type RegistrableDecoder interface {
-	RegisterDecoder(encoding.RegisterSetter) error
+	RegisterDecoder(func(name string, dec func(bool) func(io.Reader, *map[string]interface{}) error) error) error
 }
 
 // RegistrableSD defines the interface the SD plugins should implement

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -7,9 +7,6 @@ import (
 	"io/ioutil"
 	"plugin"
 	"testing"
-
-	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/sd"
 )
 
 const samplePluginName = "samplePluginName"
@@ -46,7 +43,6 @@ func ExampleRegister_Register_ok() {
 	}
 	// Output:
 	// registrable 1 from plugin samplePluginName is registering its decoder components
-	// registrable 1 from plugin samplePluginName is registering its SD components
 	// registrable 1 from plugin samplePluginName is registering its components depending on external modules
 }
 
@@ -87,27 +83,11 @@ func (r registrableDummy) RegisterDecoder(setter func(string, func(bool) func(io
 	return setter(samplePluginName, decoderFactory)
 }
 
-func (r registrableDummy) RegisterSD(setter sd.RegisterSetter) error {
-	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its SD components")
-
-	return setter.Register(samplePluginName, subscriberFactory)
-}
-
 func (r registrableDummy) RegisterExternal(setter func(string, string, interface{})) error {
 	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its components depending on external modules")
 
 	setter("namespace1", samplePluginName, func(x int) int { return 2 * x })
 	return nil
-}
-
-func subscriberFactory(cfg *config.Backend) sd.Subscriber {
-	fmt.Println("calling the SD factory:", samplePluginName)
-
-	return sd.SubscriberFunc(func() ([]string, error) {
-		fmt.Println("calling the subscriber:", samplePluginName)
-
-		return cfg.Host, nil
-	})
 }
 
 func decoderFactory(bool) func(reader io.Reader, _ *map[string]interface{}) error {

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -1,0 +1,128 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"plugin"
+	"testing"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/encoding"
+	"github.com/devopsfaith/krakend/register"
+	"github.com/devopsfaith/krakend/sd"
+)
+
+const samplePluginName = "samplePluginName"
+
+func TestRegister_Register_ok(t *testing.T) {
+	reg := NewRegister()
+	p := dummyPlugin{
+		content: plugin.Symbol(registrableDummy(1)),
+	}
+	if err := reg.Register(p); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestRegister_Register_ko(t *testing.T) {
+	reg := NewRegister()
+	p := dummyPlugin{
+		err: errors.New("some error"),
+	}
+	if err := reg.Register(p); err == nil {
+		t.Error("error expected")
+		return
+	}
+}
+
+func ExampleRegister_Register_ok() {
+	reg := NewRegister()
+	p := dummyPlugin{
+		content: plugin.Symbol(registrableDummy(1)),
+	}
+	if err := reg.Register(p); err != nil {
+		fmt.Println(err.Error())
+	}
+	// Output:
+	// registrable 1 from plugin samplePluginName is registering its decoder components
+	// registrable 1 from plugin samplePluginName is registering its SD components
+	// registrable 1 from plugin samplePluginName is registering its components depending on external modules
+}
+
+func ExampleRegister_Register_unknownInterface() {
+	reg := NewRegister()
+	p := dummyPlugin{
+		content: plugin.Symbol(1),
+	}
+	if err := reg.Register(p); err != nil {
+		fmt.Println(err.Error())
+	}
+	// Output:
+	// unknown registrable interface
+}
+
+type dummyPlugin struct {
+	content plugin.Symbol
+	err     error
+}
+
+func (d dummyPlugin) Lookup(name string) (plugin.Symbol, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+
+	if name != REGISTRABLE_VAR {
+		return nil, fmt.Errorf("unknown symbol %s", name)
+	}
+
+	return d.content, nil
+}
+
+type registrableDummy int
+
+func (r registrableDummy) RegisterDecoder(setter encoding.RegisterSetter) error {
+	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its decoder components")
+
+	return setter.Register(samplePluginName, decoderFactory)
+}
+
+func (r registrableDummy) RegisterSD(setter sd.RegisterSetter) error {
+	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its SD components")
+
+	return setter.Register(samplePluginName, subscriberFactory)
+}
+
+func (r registrableDummy) RegisterExternal(setter *register.Namespaced) error {
+	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its components depending on external modules")
+
+	setter.Register("namespace1", samplePluginName, func(x int) int { return 2 * x })
+	return nil
+}
+
+func subscriberFactory(cfg *config.Backend) sd.Subscriber {
+	fmt.Println("calling the SD factory:", samplePluginName)
+
+	return sd.SubscriberFunc(func() ([]string, error) {
+		fmt.Println("calling the subscriber:", samplePluginName)
+
+		return cfg.Host, nil
+	})
+}
+
+func decoderFactory(bool) encoding.Decoder {
+	fmt.Println("calling the decoder factory:", samplePluginName)
+
+	return func(reader io.Reader, _ *map[string]interface{}) error {
+		fmt.Println("calling the decoder:", samplePluginName)
+
+		d, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+		fmt.Println("decoder:", samplePluginName, string(d))
+		return nil
+	}
+}

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/encoding"
 	"github.com/devopsfaith/krakend/sd"
 )
 
@@ -82,10 +81,10 @@ func (d dummyPlugin) Lookup(name string) (plugin.Symbol, error) {
 
 type registrableDummy int
 
-func (r registrableDummy) RegisterDecoder(setter encoding.RegisterSetter) error {
+func (r registrableDummy) RegisterDecoder(setter func(string, func(bool) func(io.Reader, *map[string]interface{}) error) error) error {
 	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its decoder components")
 
-	return setter.Register(samplePluginName, decoderFactory)
+	return setter(samplePluginName, decoderFactory)
 }
 
 func (r registrableDummy) RegisterSD(setter sd.RegisterSetter) error {
@@ -94,7 +93,7 @@ func (r registrableDummy) RegisterSD(setter sd.RegisterSetter) error {
 	return setter.Register(samplePluginName, subscriberFactory)
 }
 
-func (r registrableDummy) RegisterExternal(setter func(namespace, name string, v interface{})) error {
+func (r registrableDummy) RegisterExternal(setter func(string, string, interface{})) error {
 	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its components depending on external modules")
 
 	setter("namespace1", samplePluginName, func(x int) int { return 2 * x })
@@ -111,7 +110,7 @@ func subscriberFactory(cfg *config.Backend) sd.Subscriber {
 	})
 }
 
-func decoderFactory(bool) encoding.Decoder {
+func decoderFactory(bool) func(reader io.Reader, _ *map[string]interface{}) error {
 	fmt.Println("calling the decoder factory:", samplePluginName)
 
 	return func(reader io.Reader, _ *map[string]interface{}) error {

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
-	"github.com/devopsfaith/krakend/register"
 	"github.com/devopsfaith/krakend/sd"
 )
 
@@ -95,10 +94,10 @@ func (r registrableDummy) RegisterSD(setter sd.RegisterSetter) error {
 	return setter.Register(samplePluginName, subscriberFactory)
 }
 
-func (r registrableDummy) RegisterExternal(setter *register.Namespaced) error {
+func (r registrableDummy) RegisterExternal(setter func(namespace, name string, v interface{})) error {
 	fmt.Println("registrable", r, "from plugin", samplePluginName, "is registering its components depending on external modules")
 
-	setter.Register("namespace1", samplePluginName, func(x int) int { return 2 * x })
+	setter("namespace1", samplePluginName, func(x int) int { return 2 * x })
 	return nil
 }
 

--- a/plugin/tests/app/main.go
+++ b/plugin/tests/app/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/plugin"
+)
+
+const pluginName = "supu"
+
+func main() {
+	register := plugin.NewRegister()
+
+	fmt.Println(plugin.Load(config.Plugin{
+		Folder:  "../plugins/",
+		Pattern: ".so",
+	}, register))
+
+	time.Sleep(5 * time.Second)
+
+	checkDecoder(register)
+	checkSD(register)
+	checkExternal(register)
+}
+
+func checkDecoder(register *plugin.Register) {
+	decoderFactory := register.Decoder.Get(pluginName)
+	decoder := decoderFactory(false)
+	d := bytes.NewBufferString("something")
+	m := &map[string]interface{}{}
+	if err := decoder(d, m); err != nil {
+		fmt.Println("error:", err.Error())
+		return
+	}
+	fmt.Println("encoding ok!")
+}
+
+func checkSD(register *plugin.Register) {
+	sdFactory := register.SD.Get(pluginName)
+	cfg := &config.Backend{Host: []string{"a", "b"}}
+	subscriber := sdFactory(cfg)
+	hosts, err := subscriber.Hosts()
+	if err != nil {
+		fmt.Println("error:", err.Error())
+		return
+	}
+	if !reflect.DeepEqual(hosts, cfg.Host) {
+		fmt.Println("unexpected set of hosts:", hosts)
+		return
+	}
+	fmt.Println("sd ok!")
+}
+
+func checkExternal(register *plugin.Register) {
+	n1Register, ok := register.External.Get("namespace1")
+	if !ok {
+		fmt.Println("namespace1 not registered")
+		return
+	}
+	v, ok := n1Register.Get(pluginName)
+	if !ok {
+		fmt.Println(pluginName, "not registered into namespace1")
+		return
+	}
+	f, ok := v.(func(int) int)
+	if !ok {
+		fmt.Println("unexpected registerd component into namespace1", v)
+		return
+	}
+	fmt.Println("f(2) =", f(2))
+}

--- a/plugin/tests/app/main.go
+++ b/plugin/tests/app/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/devopsfaith/krakend/config"
@@ -23,7 +22,6 @@ func main() {
 	time.Sleep(5 * time.Second)
 
 	checkDecoder(register)
-	checkSD(register)
 	checkExternal(register)
 }
 
@@ -37,22 +35,6 @@ func checkDecoder(register *plugin.Register) {
 		return
 	}
 	fmt.Println("encoding ok!")
-}
-
-func checkSD(register *plugin.Register) {
-	sdFactory := register.SD.Get(pluginName)
-	cfg := &config.Backend{Host: []string{"a", "b"}}
-	subscriber := sdFactory(cfg)
-	hosts, err := subscriber.Hosts()
-	if err != nil {
-		fmt.Println("error:", err.Error())
-		return
-	}
-	if !reflect.DeepEqual(hosts, cfg.Host) {
-		fmt.Println("unexpected set of hosts:", hosts)
-		return
-	}
-	fmt.Println("sd ok!")
 }
 
 func checkExternal(register *plugin.Register) {

--- a/plugin/tests/plugins/main.go
+++ b/plugin/tests/plugins/main.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 
 	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/encoding"
 	"github.com/devopsfaith/krakend/sd"
 )
 
@@ -16,10 +15,10 @@ var Registrable registrable
 
 type registrable int
 
-func (r *registrable) RegisterDecoder(setter encoding.RegisterSetter) error {
-	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its decoder components at", setter)
+func (r *registrable) RegisterDecoder(setter func(name string, dec func(bool) func(io.Reader, *map[string]interface{}) error) error) error {
+	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its decoder components")
 
-	return setter.Register(pluginName, decoderFactory)
+	return setter(pluginName, decoderFactory)
 }
 
 func (r *registrable) RegisterSD(setter sd.RegisterSetter) error {
@@ -49,7 +48,7 @@ func subscriberFactory(cfg *config.Backend) sd.Subscriber {
 	})
 }
 
-func decoderFactory(bool) encoding.Decoder {
+func decoderFactory(bool) func(reader io.Reader, _ *map[string]interface{}) error {
 	fmt.Println("calling the decoder factory:", pluginName)
 
 	return decoder

--- a/plugin/tests/plugins/main.go
+++ b/plugin/tests/plugins/main.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-
-	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/sd"
 )
 
 const pluginName = "supu"
@@ -21,12 +18,6 @@ func (r *registrable) RegisterDecoder(setter func(name string, dec func(bool) fu
 	return setter(pluginName, decoderFactory)
 }
 
-func (r *registrable) RegisterSD(setter sd.RegisterSetter) error {
-	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its SD components at", setter)
-
-	return setter.Register(pluginName, subscriberFactory)
-}
-
 func (r *registrable) RegisterExternal(setter func(namespace, name string, v interface{})) error {
 	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its components depending on external modules")
 
@@ -36,16 +27,6 @@ func (r *registrable) RegisterExternal(setter func(namespace, name string, v int
 
 func doubleInt(x int) int {
 	return 2 * x
-}
-
-func subscriberFactory(cfg *config.Backend) sd.Subscriber {
-	fmt.Println("calling the SD factory:", pluginName)
-
-	return sd.SubscriberFunc(func() ([]string, error) {
-		fmt.Println("calling the subscriber:", pluginName)
-
-		return cfg.Host, nil
-	})
 }
 
 func decoderFactory(bool) func(reader io.Reader, _ *map[string]interface{}) error {

--- a/plugin/tests/plugins/main.go
+++ b/plugin/tests/plugins/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
-	"github.com/devopsfaith/krakend/register"
 	"github.com/devopsfaith/krakend/sd"
 )
 
@@ -29,10 +28,10 @@ func (r *registrable) RegisterSD(setter sd.RegisterSetter) error {
 	return setter.Register(pluginName, subscriberFactory)
 }
 
-func (r *registrable) RegisterExternal(setter *register.Namespaced) error {
+func (r *registrable) RegisterExternal(setter func(namespace, name string, v interface{})) error {
 	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its components depending on external modules at", setter)
 
-	setter.Register("namespace1", pluginName, doubleInt)
+	setter("namespace1", pluginName, doubleInt)
 	return nil
 }
 

--- a/plugin/tests/plugins/main.go
+++ b/plugin/tests/plugins/main.go
@@ -29,7 +29,7 @@ func (r *registrable) RegisterSD(setter sd.RegisterSetter) error {
 }
 
 func (r *registrable) RegisterExternal(setter func(namespace, name string, v interface{})) error {
-	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its components depending on external modules at", setter)
+	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its components depending on external modules")
 
 	setter("namespace1", pluginName, doubleInt)
 	return nil

--- a/plugin/tests/plugins/main.go
+++ b/plugin/tests/plugins/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/encoding"
+	"github.com/devopsfaith/krakend/register"
+	"github.com/devopsfaith/krakend/sd"
+)
+
+const pluginName = "supu"
+
+var Registrable registrable
+
+type registrable int
+
+func (r *registrable) RegisterDecoder(setter encoding.RegisterSetter) error {
+	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its decoder components at", setter)
+
+	return setter.Register(pluginName, decoderFactory)
+}
+
+func (r *registrable) RegisterSD(setter sd.RegisterSetter) error {
+	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its SD components at", setter)
+
+	return setter.Register(pluginName, subscriberFactory)
+}
+
+func (r *registrable) RegisterExternal(setter *register.Namespaced) error {
+	fmt.Println("registrable", r, "from plugin", pluginName, "is registering its components depending on external modules at", setter)
+
+	setter.Register("namespace1", pluginName, doubleInt)
+	return nil
+}
+
+func doubleInt(x int) int {
+	return 2 * x
+}
+
+func subscriberFactory(cfg *config.Backend) sd.Subscriber {
+	fmt.Println("calling the SD factory:", pluginName)
+
+	return sd.SubscriberFunc(func() ([]string, error) {
+		fmt.Println("calling the subscriber:", pluginName)
+
+		return cfg.Host, nil
+	})
+}
+
+func decoderFactory(bool) encoding.Decoder {
+	fmt.Println("calling the decoder factory:", pluginName)
+
+	return decoder
+}
+
+func decoder(reader io.Reader, _ *map[string]interface{}) error {
+	fmt.Println("calling the decoder:", pluginName)
+
+	d, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	fmt.Println("decoder:", pluginName, string(d))
+	return nil
+}
+
+func main() {}

--- a/proxy/merging_test.go
+++ b/proxy/merging_test.go
@@ -275,14 +275,14 @@ func TestNewMergeDataMiddleware_noBackends(t *testing.T) {
 }
 func TestRegisterResponseCombiner(t *testing.T) {
 	subject := "test combiner"
-	if len(responseCombiners) != 1 {
-		t.Error("unexpected initial size of the response combiner list:", responseCombiners)
+	if len(responseCombiners.data.Clone()) != 1 {
+		t.Error("unexpected initial size of the response combiner list:", responseCombiners.data.Clone())
 	}
 	RegisterResponseCombiner(subject, getResponseCombiner(config.ExtraConfig{}))
-	defer delete(responseCombiners, subject)
+	defer func() { responseCombiners = initResponseCombiners() }()
 
-	if len(responseCombiners) != 2 {
-		t.Error("unexpected size of the response combiner list:", responseCombiners)
+	if len(responseCombiners.data.Clone()) != 2 {
+		t.Error("unexpected size of the response combiner list:", responseCombiners.data.Clone())
 	}
 	timeout := 500
 	backend := config.Backend{}

--- a/proxy/register.go
+++ b/proxy/register.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"github.com/devopsfaith/krakend/register"
+)
+
+type ResponseCombinerRegister interface {
+	GetResponseCombiner(string) (ResponseCombiner, bool)
+	SetResponseCombiner(string, ResponseCombiner)
+}
+
+func NewRegister() *Register {
+	return &Register{
+		responseCombiners,
+	}
+}
+
+type Register struct {
+	*combinerRegister
+}
+
+type combinerRegister struct {
+	data     register.Untyped
+	fallback ResponseCombiner
+}
+
+func newCombinerRegister(data map[string]ResponseCombiner, fallback ResponseCombiner) *combinerRegister {
+	r := register.NewUntyped()
+	for k, v := range data {
+		r.Register(k, v)
+	}
+	return &combinerRegister{r, fallback}
+}
+
+func (r *combinerRegister) GetResponseCombiner(name string) (ResponseCombiner, bool) {
+	v, ok := r.data.Get(name)
+	if !ok {
+		return r.fallback, ok
+	}
+	if rc, ok := v.(ResponseCombiner); ok {
+		return rc, ok
+	}
+	return r.fallback, ok
+}
+
+func (r *combinerRegister) SetResponseCombiner(name string, rc ResponseCombiner) {
+	r.data.Register(name, rc)
+}

--- a/proxy/register.go
+++ b/proxy/register.go
@@ -4,11 +4,6 @@ import (
 	"github.com/devopsfaith/krakend/register"
 )
 
-type ResponseCombinerRegister interface {
-	GetResponseCombiner(string) (ResponseCombiner, bool)
-	SetResponseCombiner(string, ResponseCombiner)
-}
-
 func NewRegister() *Register {
 	return &Register{
 		responseCombiners,

--- a/proxy/register_test.go
+++ b/proxy/register_test.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewRegister_responseCombiner_ok(t *testing.T) {
+	r := NewRegister()
+	r.SetResponseCombiner("name1", func(_ context.Context, total int, parts []*Response) *Response {
+		if total < 0 || total >= len(parts) {
+			return nil
+		}
+		return parts[total]
+	})
+
+	rc, ok := r.GetResponseCombiner("name1")
+	if !ok {
+		t.Error("expecting response combiner")
+		return
+	}
+
+	result := rc(context.Background(), 0, []*Response{{IsComplete: true, Data: map[string]interface{}{"a": 42}}})
+
+	if result == nil {
+		t.Error("expecting result")
+		return
+	}
+
+	if !result.IsComplete {
+		t.Error("expecting a complete result")
+		return
+	}
+
+	if len(result.Data) != 1 {
+		t.Error("unexpected result size:", len(result.Data))
+		return
+	}
+}
+
+func TestNewRegister_responseCombiner_fallbackIfErrored(t *testing.T) {
+	r := NewRegister()
+
+	r.data.Register("errored", true)
+
+	rc, ok := r.GetResponseCombiner("errored")
+	if !ok {
+		t.Error("expecting response combiner")
+		return
+	}
+
+	original := &Response{IsComplete: true, Data: map[string]interface{}{"a": 42}}
+
+	result := rc(context.Background(), 0, []*Response{original})
+
+	if result != original {
+		t.Error("unexpected result:", result)
+		return
+	}
+}
+
+func TestNewRegister_responseCombiner_fallbackIfUnknown(t *testing.T) {
+	r := NewRegister()
+
+	rc, ok := r.GetResponseCombiner("unkown")
+	if ok {
+		t.Error("the response combiner should not be found")
+		return
+	}
+
+	original := &Response{IsComplete: true, Data: map[string]interface{}{"a": 42}}
+
+	result := rc(context.Background(), 0, []*Response{original})
+
+	if result != original {
+		t.Error("unexpected result:", result)
+		return
+	}
+}

--- a/register/internal/untyped_go19.go
+++ b/register/internal/untyped_go19.go
@@ -1,0 +1,17 @@
+// +build go1.9
+
+package internal
+
+import "sync"
+
+type Untyped struct {
+	data sync.Map
+}
+
+func (u *Untyped) Register(name string, v interface{}) {
+	u.data.Store(name, v)
+}
+
+func (u *Untyped) Get(name string) (interface{}, bool) {
+	return u.data.Load(name)
+}

--- a/register/internal/untyped_go19.go
+++ b/register/internal/untyped_go19.go
@@ -4,8 +4,14 @@ package internal
 
 import "sync"
 
+func NewUntyped() *Untyped {
+	return &Untyped{
+		data: &sync.Map{},
+	}
+}
+
 type Untyped struct {
-	data sync.Map
+	data *sync.Map
 }
 
 func (u *Untyped) Register(name string, v interface{}) {

--- a/register/internal/untyped_go19.go
+++ b/register/internal/untyped_go19.go
@@ -5,9 +5,7 @@ package internal
 import "sync"
 
 func NewUntyped() *Untyped {
-	return &Untyped{
-		data: &sync.Map{},
-	}
+	return &Untyped{&sync.Map{}}
 }
 
 type Untyped struct {
@@ -20,4 +18,13 @@ func (u *Untyped) Register(name string, v interface{}) {
 
 func (u *Untyped) Get(name string) (interface{}, bool) {
 	return u.data.Load(name)
+}
+
+func (u *Untyped) Clone() map[string]interface{} {
+	res := map[string]interface{}{}
+	u.data.Range(func(key, value interface{}) bool {
+		res[key.(string)] = value
+		return true
+	})
+	return res
 }

--- a/register/internal/untyped_other.go
+++ b/register/internal/untyped_other.go
@@ -1,0 +1,23 @@
+// +build !go1.9
+
+package internal
+
+import "sync"
+
+type Untyped struct {
+	data  map[string]interface{}
+	mutex *sync.RWMutex
+}
+
+func (u *Untyped) Register(name string, v interface{}) {
+	u.mutex.Lock()
+	u.data[name] = v
+	u.mutex.Unlock()
+}
+
+func (u *Untyped) Get(name string) (interface{}, bool) {
+	u.mutex.RLock()
+	v, ok := u.data[name]
+	u.mutex.RUnlock()
+	return v, ok
+}

--- a/register/internal/untyped_other.go
+++ b/register/internal/untyped_other.go
@@ -28,3 +28,13 @@ func (u *Untyped) Get(name string) (interface{}, bool) {
 	u.mutex.RUnlock()
 	return v, ok
 }
+
+func (u *Untyped) Clone() map[string]interface{} {
+	u.mutex.RLock()
+	res := make(map[string]interface{}, len(u.data))
+	for k, v := range u.data {
+		res[k] = v
+	}
+	u.mutex.RUnlock()
+	return res
+}

--- a/register/internal/untyped_other.go
+++ b/register/internal/untyped_other.go
@@ -4,6 +4,13 @@ package internal
 
 import "sync"
 
+func NewUntyped() *Untyped {
+	return &Untyped{
+		data:  map[string]interface{}{},
+		mutex: &sync.RWMutex{},
+	}
+}
+
 type Untyped struct {
 	data  map[string]interface{}
 	mutex *sync.RWMutex

--- a/register/register.go
+++ b/register/register.go
@@ -30,7 +30,7 @@ func (n *Namespaced) Register(namespace, name string, v interface{}) {
 	if r, ok := n.data[namespace]; ok {
 		r.Register(name, v)
 	} else {
-		n.data[namespace] = new(internal.Untyped)
+		n.data[namespace] = internal.NewUntyped()
 		n.data[namespace].Register(name, v)
 	}
 	n.mutex.Unlock()
@@ -38,6 +38,6 @@ func (n *Namespaced) Register(namespace, name string, v interface{}) {
 
 func (n *Namespaced) AddNamespace(namespace string) {
 	n.mutex.Lock()
-	n.data[namespace] = new(internal.Untyped)
+	n.data[namespace] = internal.NewUntyped()
 	n.mutex.Unlock()
 }

--- a/register/register.go
+++ b/register/register.go
@@ -1,43 +1,50 @@
 package register
 
 import (
-	"sync"
-
 	"github.com/devopsfaith/krakend/register/internal"
 )
 
 func New() *Namespaced {
-	return &Namespaced{
-		data:  map[string]*internal.Untyped{},
-		mutex: &sync.RWMutex{},
-	}
+	return &Namespaced{NewUntyped()}
 }
 
 type Namespaced struct {
-	data  map[string]*internal.Untyped
-	mutex *sync.RWMutex
+	data Untyped
 }
 
-func (u *Namespaced) Get(namespace string) (*internal.Untyped, bool) {
-	u.mutex.Lock()
-	v, ok := u.data[namespace]
-	u.mutex.Unlock()
-	return v, ok
+func (n *Namespaced) Get(namespace string) (Untyped, bool) {
+	v, ok := n.data.Get(namespace)
+	if !ok {
+		return nil, ok
+	}
+	register, ok := v.(Untyped)
+	return register, ok
 }
 
 func (n *Namespaced) Register(namespace, name string, v interface{}) {
-	n.mutex.Lock()
-	if r, ok := n.data[namespace]; ok {
-		r.Register(name, v)
-	} else {
-		n.data[namespace] = internal.NewUntyped()
-		n.data[namespace].Register(name, v)
+	if register, ok := n.Get(namespace); ok {
+		register.Register(name, v)
+		return
 	}
-	n.mutex.Unlock()
+
+	register := NewUntyped()
+	register.Register(name, v)
+	n.data.Register(namespace, register)
 }
 
 func (n *Namespaced) AddNamespace(namespace string) {
-	n.mutex.Lock()
-	n.data[namespace] = internal.NewUntyped()
-	n.mutex.Unlock()
+	if _, ok := n.Get(namespace); ok {
+		return
+	}
+	n.data.Register(namespace, NewUntyped())
+}
+
+type Untyped interface {
+	Register(name string, v interface{})
+	Get(name string) (interface{}, bool)
+	Clone() map[string]interface{}
+}
+
+func NewUntyped() Untyped {
+	return internal.NewUntyped()
 }

--- a/register/register.go
+++ b/register/register.go
@@ -2,18 +2,27 @@ package register
 
 import (
 	"sync"
+
+	"github.com/devopsfaith/krakend/register/internal"
 )
 
 func New() *Namespaced {
 	return &Namespaced{
-		data:  map[string]*Untyped{},
+		data:  map[string]*internal.Untyped{},
 		mutex: &sync.RWMutex{},
 	}
 }
 
 type Namespaced struct {
-	data  map[string]*Untyped
+	data  map[string]*internal.Untyped
 	mutex *sync.RWMutex
+}
+
+func (u *Namespaced) Get(namespace string) (*internal.Untyped, bool) {
+	u.mutex.Lock()
+	v, ok := u.data[namespace]
+	u.mutex.Unlock()
+	return v, ok
 }
 
 func (n *Namespaced) Register(namespace, name string, v interface{}) {
@@ -21,33 +30,14 @@ func (n *Namespaced) Register(namespace, name string, v interface{}) {
 	if r, ok := n.data[namespace]; ok {
 		r.Register(name, v)
 	} else {
-		n.data[namespace] = &Untyped{}
+		n.data[namespace] = new(internal.Untyped)
 		n.data[namespace].Register(name, v)
 	}
 	n.mutex.Unlock()
 }
 
-func (u *Namespaced) Get(namespace string) (*Untyped, bool) {
-	u.mutex.Lock()
-	v, ok := u.data[namespace]
-	u.mutex.Unlock()
-	return v, ok
-}
-
 func (n *Namespaced) AddNamespace(namespace string) {
 	n.mutex.Lock()
-	n.data[namespace] = &Untyped{}
+	n.data[namespace] = new(internal.Untyped)
 	n.mutex.Unlock()
-}
-
-type Untyped struct {
-	data sync.Map
-}
-
-func (u *Untyped) Register(name string, v interface{}) {
-	u.data.Store(name, v)
-}
-
-func (u *Untyped) Get(name string) (interface{}, bool) {
-	return u.data.Load(name)
 }

--- a/register/register.go
+++ b/register/register.go
@@ -1,0 +1,53 @@
+package register
+
+import (
+	"sync"
+)
+
+func New() *Namespaced {
+	return &Namespaced{
+		data:  map[string]*Untyped{},
+		mutex: &sync.RWMutex{},
+	}
+}
+
+type Namespaced struct {
+	data  map[string]*Untyped
+	mutex *sync.RWMutex
+}
+
+func (n *Namespaced) Register(namespace, name string, v interface{}) {
+	n.mutex.Lock()
+	if r, ok := n.data[namespace]; ok {
+		r.Register(name, v)
+	} else {
+		n.data[namespace] = &Untyped{}
+		n.data[namespace].Register(name, v)
+	}
+	n.mutex.Unlock()
+}
+
+func (u *Namespaced) Get(namespace string) (*Untyped, bool) {
+	u.mutex.Lock()
+	v, ok := u.data[namespace]
+	u.mutex.Unlock()
+	return v, ok
+}
+
+func (n *Namespaced) AddNamespace(namespace string) {
+	n.mutex.Lock()
+	n.data[namespace] = &Untyped{}
+	n.mutex.Unlock()
+}
+
+type Untyped struct {
+	data sync.Map
+}
+
+func (u *Untyped) Register(name string, v interface{}) {
+	u.data.Store(name, v)
+}
+
+func (u *Untyped) Get(name string) (interface{}, bool) {
+	return u.data.Load(name)
+}

--- a/register/register_test.go
+++ b/register/register_test.go
@@ -5,6 +5,7 @@ import "testing"
 func Test(t *testing.T) {
 	r := New()
 	r.Register("namespace1", "name1", 42)
+	r.AddNamespace("namespace1")
 	r.AddNamespace("namespace2")
 	r.Register("namespace2", "name2", true)
 

--- a/register/register_test.go
+++ b/register/register_test.go
@@ -1,0 +1,46 @@
+package register
+
+import "testing"
+
+func Test(t *testing.T) {
+	r := New()
+	r.Register("namespace1", "name1", 42)
+	r.AddNamespace("namespace2")
+	r.Register("namespace2", "name2", true)
+
+	nr, ok := r.Get("namespace1")
+	if !ok {
+		t.Error("namespace1 not found")
+		return
+	}
+	if _, ok := nr.Get("name2"); ok {
+		t.Error("name2 found into namespace1")
+		return
+	}
+	v1, ok := nr.Get("name1")
+	if !ok {
+		t.Error("name1 not found")
+		return
+	}
+	if i, ok := v1.(int); !ok || i != 42 {
+		t.Error("unexpected value:", v1)
+	}
+
+	nr, ok = r.Get("namespace2")
+	if !ok {
+		t.Error("namespace2 not found")
+		return
+	}
+	if _, ok := nr.Get("name1"); ok {
+		t.Error("name1 found into namespace2")
+		return
+	}
+	v2, ok := nr.Get("name2")
+	if !ok {
+		t.Error("name2 not found")
+		return
+	}
+	if b, ok := v2.(bool); !ok || !b {
+		t.Error("unexpected value:", v2)
+	}
+}

--- a/sd/register.go
+++ b/sd/register.go
@@ -36,7 +36,9 @@ type Register struct {
 	data register.Untyped
 }
 
-var subscriberFactories = &Register{register.NewUntyped()}
+func initRegister() *Register {
+	return &Register{register.NewUntyped()}
+}
 
 // Register implements the RegisterSetter interface
 func (r *Register) Register(name string, sf SubscriberFactory) error {
@@ -56,3 +58,5 @@ func (r *Register) Get(name string) SubscriberFactory {
 	}
 	return sf
 }
+
+var subscriberFactories = initRegister()

--- a/sd/register.go
+++ b/sd/register.go
@@ -1,21 +1,63 @@
 package sd
 
-import "github.com/devopsfaith/krakend/config"
+import (
+	"sync"
 
-// RegisterSubscriberFactory registers the received subscriber factory for later usage
+	"github.com/devopsfaith/krakend/config"
+)
+
+// Deprecated: RegisterSubscriberFactory. Use the GetRegister function
 func RegisterSubscriberFactory(name string, sf SubscriberFactory) error {
-	subscriberFactories[name] = sf
+	return subscriberFactories.Register(name, sf)
+}
+
+// Deprecated: GetSubscriber. Use the GetRegister function
+func GetSubscriber(cfg *config.Backend) Subscriber {
+	return subscriberFactories.Get(cfg.SD)(cfg)
+}
+
+// RegisterSetter registers the received subscriber factory for later usage
+type RegisterSetter interface {
+	Register(name string, sf SubscriberFactory) error
+}
+
+// RegisterGetter gets the subscriber factory by name or a fixed subscriber factory if
+// the name is not registered
+type RegisterGetter interface {
+	Get(name string) SubscriberFactory
+}
+
+// GetRegister returns the package register
+func GetRegister() *Register {
+	return subscriberFactories
+}
+
+// Register is a SD register
+type Register struct {
+	data  map[string]SubscriberFactory
+	mutex *sync.RWMutex
+}
+
+var subscriberFactories = &Register{
+	data:  map[string]SubscriberFactory{},
+	mutex: &sync.RWMutex{},
+}
+
+// Register implements the RegisterSetter interface
+func (r *Register) Register(name string, sf SubscriberFactory) error {
+	r.mutex.Lock()
+	r.data[name] = sf
+	r.mutex.Unlock()
 	return nil
 }
 
-// GetSubscriber gets the subscriber factory by name or a fixed subscriber factory if
-// the name is not registered
-func GetSubscriber(cfg *config.Backend) Subscriber {
-	sf, ok := subscriberFactories[cfg.SD]
+// Get implements the RegisterGetter interface
+func (r *Register) Get(name string) SubscriberFactory {
+	r.mutex.RLock()
+	sf, ok := r.data[name]
+	r.mutex.RUnlock()
 	if !ok {
-		return FixedSubscriberFactory(cfg)
+		return FixedSubscriberFactory
 	}
-	return sf(cfg)
+	return sf
 }
-
-var subscriberFactories = map[string]SubscriberFactory{}

--- a/sd/register.go
+++ b/sd/register.go
@@ -15,17 +15,6 @@ func GetSubscriber(cfg *config.Backend) Subscriber {
 	return subscriberFactories.Get(cfg.SD)(cfg)
 }
 
-// RegisterSetter registers the received subscriber factory for later usage
-type RegisterSetter interface {
-	Register(name string, sf SubscriberFactory) error
-}
-
-// RegisterGetter gets the subscriber factory by name or a fixed subscriber factory if
-// the name is not registered
-type RegisterGetter interface {
-	Get(name string) SubscriberFactory
-}
-
 // GetRegister returns the package register
 func GetRegister() *Register {
 	return subscriberFactories

--- a/sd/register_test.go
+++ b/sd/register_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/register"
 )
 
 func TestRegisterSubscriberFactory_ok(t *testing.T) {
@@ -33,7 +32,7 @@ func TestRegisterSubscriberFactory_ok(t *testing.T) {
 		t.Error("error using the sd name2")
 	}
 
-	subscriberFactories = &Register{register.NewUntyped()}
+	subscriberFactories = initRegister()
 }
 
 func TestRegisterSubscriberFactory_unknown(t *testing.T) {
@@ -47,5 +46,5 @@ func TestRegisterSubscriberFactory_errored(t *testing.T) {
 	if h, err := GetSubscriber(&config.Backend{SD: "errored", Host: []string{"name"}}).Hosts(); err != nil || len(h) != 1 {
 		t.Error("error using the default sd")
 	}
-	subscriberFactories = &Register{register.NewUntyped()}
+	subscriberFactories = initRegister()
 }

--- a/sd/register_test.go
+++ b/sd/register_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/register"
 )
 
-func TestRegisterSubscriberFactory(t *testing.T) {
+func TestRegisterSubscriberFactory_ok(t *testing.T) {
 	sf1 := func(*config.Backend) Subscriber {
 		return SubscriberFunc(func() ([]string, error) { return []string{"one"}, nil })
 	}
@@ -28,7 +29,23 @@ func TestRegisterSubscriberFactory(t *testing.T) {
 		t.Error("error using the sd name2")
 	}
 
+	if h, err := GetRegister().Get("name2")(&config.Backend{SD: "name2"}).Hosts(); err != nil || len(h) != 2 {
+		t.Error("error using the sd name2")
+	}
+
+	subscriberFactories = &Register{register.NewUntyped()}
+}
+
+func TestRegisterSubscriberFactory_unknown(t *testing.T) {
 	if h, err := GetSubscriber(&config.Backend{Host: []string{"name"}}).Hosts(); err != nil || len(h) != 1 {
 		t.Error("error using the default sd")
 	}
+}
+
+func TestRegisterSubscriberFactory_errored(t *testing.T) {
+	subscriberFactories.data.Register("errored", true)
+	if h, err := GetSubscriber(&config.Backend{SD: "errored", Host: []string{"name"}}).Hosts(); err != nil || len(h) != 1 {
+		t.Error("error using the default sd")
+	}
+	subscriberFactories = &Register{register.NewUntyped()}
 }


### PR DESCRIPTION
This PR adds:

- a `register` package so all the registers in the framework can re-use its implementations. Internally, it has an alternative implementation to the `sync.Map` for supporting golang1.8
- a `Register` struct in the `plugin` module so plugins can be auto-registering themselves on the received register function after being loaded
- a minimal integration test for the plugin experimental feature
