### PR TITLE
Remove the context from the response combiner signature

### DIFF
--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -49,7 +49,7 @@ func NewMergeDataMiddleware(endpointConfig *config.EndpointConfig) Middleware {
 				return &Response{Data: make(map[string]interface{}), IsComplete: false}, err
 			}
 
-			result := combiner(localCtx, totalBackends, responses)
+			result := combiner(totalBackends, responses)
 			cancel()
 			return result, err
 		}
@@ -79,7 +79,7 @@ func requestPart(ctx context.Context, next Proxy, request *Request, out chan<- *
 }
 
 // ResponseCombiner func to merge the collected responses into a single one
-type ResponseCombiner func(context.Context, int, []*Response) *Response
+type ResponseCombiner func(int, []*Response) *Response
 
 // RegisterResponseCombiner adds a new response combiner into the internal register
 func RegisterResponseCombiner(name string, f ResponseCombiner) {
@@ -111,7 +111,7 @@ func getResponseCombiner(extra config.ExtraConfig) ResponseCombiner {
 	return combiner
 }
 
-func combineData(_ context.Context, total int, parts []*Response) *Response {
+func combineData(total int, parts []*Response) *Response {
 	isComplete := len(parts) == total
 	var retResponse *Response
 	for _, part := range parts {

--- a/proxy/register_test.go
+++ b/proxy/register_test.go
@@ -1,13 +1,12 @@
 package proxy
 
 import (
-	"context"
 	"testing"
 )
 
 func TestNewRegister_responseCombiner_ok(t *testing.T) {
 	r := NewRegister()
-	r.SetResponseCombiner("name1", func(_ context.Context, total int, parts []*Response) *Response {
+	r.SetResponseCombiner("name1", func(total int, parts []*Response) *Response {
 		if total < 0 || total >= len(parts) {
 			return nil
 		}
@@ -20,7 +19,7 @@ func TestNewRegister_responseCombiner_ok(t *testing.T) {
 		return
 	}
 
-	result := rc(context.Background(), 0, []*Response{{IsComplete: true, Data: map[string]interface{}{"a": 42}}})
+	result := rc(0, []*Response{{IsComplete: true, Data: map[string]interface{}{"a": 42}}})
 
 	if result == nil {
 		t.Error("expecting result")
@@ -51,7 +50,7 @@ func TestNewRegister_responseCombiner_fallbackIfErrored(t *testing.T) {
 
 	original := &Response{IsComplete: true, Data: map[string]interface{}{"a": 42}}
 
-	result := rc(context.Background(), 0, []*Response{original})
+	result := rc(0, []*Response{original})
 
 	if result != original {
 		t.Error("unexpected result:", result)
@@ -70,7 +69,7 @@ func TestNewRegister_responseCombiner_fallbackIfUnknown(t *testing.T) {
 
 	original := &Response{IsComplete: true, Data: map[string]interface{}{"a": 42}}
 
-	result := rc(context.Background(), 0, []*Response{original})
+	result := rc(0, []*Response{original})
 
 	if result != original {
 		t.Error("unexpected result:", result)


### PR DESCRIPTION
as detected in #81, the response combiner interface does not require a context