### PR TITLE
LoadBalancer optimizations

### DIFF
--- a/sd/loadbalancing.go
+++ b/sd/loadbalancing.go
@@ -16,6 +16,9 @@ var ErrNoHosts = errors.New("no hosts available")
 
 // NewRoundRobinLB returns a new balancer using a round robin strategy
 func NewRoundRobinLB(subscriber Subscriber) Balancer {
+	if s, ok := subscriber.(FixedSubscriber); ok && len(s) == 1 {
+		return nopBalancer(s[0])
+	}
 	return &roundRobinLB{
 		subscriber: subscriber,
 		counter:    0,
@@ -42,6 +45,9 @@ func (rr *roundRobinLB) Host() (string, error) {
 
 // NewRandomLB returns a new balancer using a pseudo-random strategy
 func NewRandomLB(subscriber Subscriber, seed int64) Balancer {
+	if s, ok := subscriber.(FixedSubscriber); ok && len(s) == 1 {
+		return nopBalancer(s[0])
+	}
 	return &randomLB{
 		subscriber: subscriber,
 		rnd:        rand.New(rand.NewSource(seed)),
@@ -64,3 +70,7 @@ func (r *randomLB) Host() (string, error) {
 	}
 	return hosts[r.rnd.Intn(len(hosts))], nil
 }
+
+type nopBalancer string
+
+func (b nopBalancer) Host() (string, error) { return string(b), nil }

--- a/sd/loadbalancing_benchmark_test.go
+++ b/sd/loadbalancing_benchmark_test.go
@@ -1,0 +1,50 @@
+package sd
+
+import (
+	"fmt"
+	"testing"
+)
+
+var balancerTestsCases = [][]string{
+	{"a"},
+	{"a", "b", "c"},
+	{"a", "b", "c", "e", "f"},
+}
+
+func BenchmarkRoundRobinLB(b *testing.B) {
+	for _, testCase := range balancerTestsCases {
+		b.Run(fmt.Sprintf("%d hosts", len(testCase)), func(b *testing.B) {
+			balancer := NewRoundRobinLB(FixedSubscriber(testCase))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				balancer.Host()
+			}
+		})
+	}
+}
+
+func BenchmarkRoundRobinLB_parallel(b *testing.B) {
+	for _, testCase := range balancerTestsCases {
+		b.Run(fmt.Sprintf("%d hosts", len(testCase)), func(b *testing.B) {
+			balancer := NewRoundRobinLB(FixedSubscriber(testCase))
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					balancer.Host()
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkRandomLB(b *testing.B) {
+	for _, testCase := range balancerTestsCases {
+		b.Run(fmt.Sprintf("%d hosts", len(testCase)), func(b *testing.B) {
+			balancer := NewRandomLB(FixedSubscriber(testCase), 1415926)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				balancer.Host()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Do not balance over a `sd.FixedSubscriber` with a single host.