### PR TITLE
Add an explicit header about response completeness

### DIFF
--- a/router/gin/endpoint_test.go
+++ b/router/gin/endpoint_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 )
 
 func TestEndpointHandler_ok(t *testing.T) {
@@ -36,7 +37,7 @@ func TestEndpointHandler_ok(t *testing.T) {
 		}, nil
 	}
 	expectedBody := "{\"supu\":\"tupu\"}"
-	testEndpointHandler(t, 10, p, expectedBody, "public, max-age=21600", "application/json; charset=utf-8", http.StatusOK)
+	testEndpointHandler(t, 10, p, expectedBody, "public, max-age=21600", "application/json; charset=utf-8", http.StatusOK, true)
 }
 
 var ctxContent = map[string]interface{}{
@@ -53,14 +54,14 @@ func TestEndpointHandler_incomplete(t *testing.T) {
 		}, nil
 	}
 	expectedBody := "{\"foo\":\"bar\"}"
-	testEndpointHandler(t, 10, p, expectedBody, "", "application/json; charset=utf-8", http.StatusOK)
+	testEndpointHandler(t, 10, p, expectedBody, "", "application/json; charset=utf-8", http.StatusOK, false)
 }
 
 func TestEndpointHandler_ko(t *testing.T) {
 	p := func(_ context.Context, _ *proxy.Request) (*proxy.Response, error) {
 		return nil, fmt.Errorf("This is %s", "a dummy error")
 	}
-	testEndpointHandler(t, 10, p, "", "", "", http.StatusInternalServerError)
+	testEndpointHandler(t, 10, p, "", "", "", http.StatusInternalServerError, false)
 }
 
 func TestEndpointHandler_cancel(t *testing.T) {
@@ -68,15 +69,15 @@ func TestEndpointHandler_cancel(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		return nil, nil
 	}
-	testEndpointHandler(t, 0, p, "", "", "", http.StatusInternalServerError)
+	testEndpointHandler(t, 0, p, "", "", "", http.StatusInternalServerError, false)
 }
 
 func TestEndpointHandler_noop(t *testing.T) {
-	testEndpointHandler(t, 10, proxy.NoopProxy, "{}", "", "application/json; charset=utf-8", http.StatusOK)
+	testEndpointHandler(t, 10, proxy.NoopProxy, "{}", "", "application/json; charset=utf-8", http.StatusOK, false)
 }
 
 func testEndpointHandler(t *testing.T, timeout time.Duration, p proxy.Proxy, expectedBody, expectedCache,
-	expectedContent string, expectedStatusCode int) {
+	expectedContent string, expectedStatusCode int, completed bool) {
 	body, resp, err := setup(timeout, p)
 	if err != nil {
 		t.Error("Reading the response:", err.Error())
@@ -85,6 +86,12 @@ func testEndpointHandler(t *testing.T, timeout time.Duration, p proxy.Proxy, exp
 	content := string(body)
 	if resp.Header.Get("Cache-Control") != expectedCache {
 		t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+	}
+	if completed && resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderCompleteResponseValue {
+		t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
+	}
+	if !completed && resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderIncompleteResponseValue {
+		t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 	}
 	if resp.Header.Get("Content-Type") != expectedContent {
 		t.Error("Content-Type error:", resp.Header.Get("Content-Type"))

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -48,7 +48,7 @@ type factory struct {
 
 // New implements the factory interface
 func (rf factory) New() router.Router {
-	return ginRouter{rf.cfg, context.Background()}
+	return rf.NewWithContext(context.Background())
 }
 
 // NewWithContext implements the factory interface
@@ -82,6 +82,10 @@ func (r ginRouter) Run(cfg config.ServiceConfig) {
 	}
 
 	r.registerKrakendEndpoints(cfg.Endpoints)
+
+	r.cfg.Engine.NoRoute(func(c *gin.Context) {
+		c.Header(router.CompleteResponseHeaderName, router.HeaderIncompleteResponseValue)
+	})
 
 	s := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 )
 
 func TestDefaultFactory_ok(t *testing.T) {
@@ -99,6 +100,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 		content := string(body)
 		if resp.Header.Get("Cache-Control") != "" {
 			t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+		}
+		if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderCompleteResponseValue {
+			t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 		}
 		if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
 			t.Error("Content-Type error:", resp.Header.Get("Content-Type"))
@@ -230,19 +234,22 @@ func checkResponseIs404(t *testing.T, req *http.Request) {
 	}
 	content := string(body)
 	if resp.Header.Get("Cache-Control") != "" {
-		t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+		t.Error(req.URL.String(), "Cache-Control error:", resp.Header.Get("Cache-Control"))
+	}
+	if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderIncompleteResponseValue {
+		t.Error(req.URL.String(), router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 	}
 	if resp.Header.Get("Content-Type") != "text/plain" {
-		t.Error("Content-Type error:", resp.Header.Get("Content-Type"))
+		t.Error(req.URL.String(), "Content-Type error:", resp.Header.Get("Content-Type"))
 	}
 	if resp.Header.Get("X-Krakend") != "" {
-		t.Error("X-Krakend error:", resp.Header.Get("X-Krakend"))
+		t.Error(req.URL.String(), "X-Krakend error:", resp.Header.Get("X-Krakend"))
 	}
 	if resp.StatusCode != http.StatusNotFound {
-		t.Error("Unexpected status code:", resp.StatusCode)
+		t.Error(req.URL.String(), "Unexpected status code:", resp.StatusCode)
 	}
 	if content != expectedBody {
-		t.Error("Unexpected body:", content, "expected:", expectedBody)
+		t.Error(req.URL.String(), "Unexpected body:", content, "expected:", expectedBody)
 	}
 }
 

--- a/router/gorilla/router.go
+++ b/router/gorilla/router.go
@@ -48,5 +48,5 @@ func (g gorillaEngine) Handle(pattern string, handler http.Handler) {
 
 // ServeHTTP implements the http:Handler interface from the stdlib
 func (g gorillaEngine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	g.r.ServeHTTP(w, r)
+	g.r.ServeHTTP(mux.NewHTTPErrorInterceptor(w), r)
 }

--- a/router/gorilla/router_test.go
+++ b/router/gorilla/router_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 )
 
 func TestDefaultFactory_ok(t *testing.T) {
@@ -99,6 +100,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 		content := string(body)
 		if resp.Header.Get("Cache-Control") != "" {
 			t.Error(endpoint.Endpoint, "Cache-Control error:", resp.Header.Get("Cache-Control"))
+		}
+		if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderCompleteResponseValue {
+			t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 		}
 		if resp.Header.Get("Content-Type") != "application/json" {
 			t.Error(endpoint.Endpoint, "Content-Type error:", resp.Header.Get("Content-Type"))
@@ -231,6 +235,9 @@ func checkResponseIs404(t *testing.T, req *http.Request) {
 	content := string(body)
 	if resp.Header.Get("Cache-Control") != "" {
 		t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+	}
+	if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderIncompleteResponseValue {
+		t.Error(req.URL.String(), router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 	}
 	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Error("Content-Type error:", resp.Header.Get("Content-Type"))

--- a/router/mux/engine.go
+++ b/router/mux/engine.go
@@ -1,0 +1,50 @@
+// Package mux provides some basic implementations for building routers based on net/http mux
+package mux
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/devopsfaith/krakend/router"
+)
+
+// Engine defines the minimun required interface for the mux compatible engine
+type Engine interface {
+	http.Handler
+	Handle(pattern string, handler http.Handler)
+}
+
+// DefaultEngine returns a new engine using a sligthly customized http.ServeMux router
+func DefaultEngine() *engine {
+	return &engine{http.NewServeMux()}
+}
+
+type engine struct {
+	handler Engine
+}
+
+func (e *engine) Handle(pattern string, handler http.Handler) {
+	e.handler.Handle(pattern, handler)
+}
+
+func (e *engine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e.handler.ServeHTTP(newHTTPErrorInterceptor(w), r)
+}
+
+func newHTTPErrorInterceptor(w http.ResponseWriter) *HTTPErrorInterceptor {
+	return &HTTPErrorInterceptor{w, new(sync.Once)}
+}
+
+type HTTPErrorInterceptor struct {
+	http.ResponseWriter
+	once *sync.Once
+}
+
+func (i *HTTPErrorInterceptor) WriteHeader(code int) {
+	i.once.Do(func() {
+		if code != http.StatusOK {
+			i.ResponseWriter.Header().Set(router.CompleteResponseHeaderName, router.HeaderIncompleteResponseValue)
+		}
+	})
+	i.ResponseWriter.WriteHeader(code)
+}

--- a/router/mux/engine.go
+++ b/router/mux/engine.go
@@ -28,10 +28,10 @@ func (e *engine) Handle(pattern string, handler http.Handler) {
 }
 
 func (e *engine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	e.handler.ServeHTTP(newHTTPErrorInterceptor(w), r)
+	e.handler.ServeHTTP(NewHTTPErrorInterceptor(w), r)
 }
 
-func newHTTPErrorInterceptor(w http.ResponseWriter) *HTTPErrorInterceptor {
+func NewHTTPErrorInterceptor(w http.ResponseWriter) *HTTPErrorInterceptor {
 	return &HTTPErrorInterceptor{w, new(sync.Once)}
 }
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -15,17 +15,6 @@ import (
 // DefaultDebugPattern is the default pattern used to define the debug endpoint
 const DefaultDebugPattern = "/__debug/"
 
-// Engine defines the minimun required interface for the mux compatible engine
-type Engine interface {
-	http.Handler
-	Handle(pattern string, handler http.Handler)
-}
-
-// DefaultEngine returns a new engine using the http.ServeMux router
-func DefaultEngine() *http.ServeMux {
-	return http.NewServeMux()
-}
-
 // Config is the struct that collects the parts the router should be builded from
 type Config struct {
 	Engine         Engine

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 )
 
 func TestDefaultFactory_ok(t *testing.T) {
@@ -99,6 +100,9 @@ func TestDefaultFactory_ok(t *testing.T) {
 		content := string(body)
 		if resp.Header.Get("Cache-Control") != "" {
 			t.Error(endpoint.Endpoint, "Cache-Control error:", resp.Header.Get("Cache-Control"))
+		}
+		if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderCompleteResponseValue {
+			t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 		}
 		if resp.Header.Get("Content-Type") != "application/json" {
 			t.Error(endpoint.Endpoint, "Content-Type error:", resp.Header.Get("Content-Type"))
@@ -237,6 +241,9 @@ func checkResponseIs404(t *testing.T, req *http.Request) {
 	content := string(body)
 	if resp.Header.Get("Cache-Control") != "" {
 		t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+	}
+	if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderIncompleteResponseValue {
+		t.Error(req.URL.String(), router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 	}
 	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Error("Content-Type error:", resp.Header.Get("Content-Type"))

--- a/router/negroni/router.go
+++ b/router/negroni/router.go
@@ -59,5 +59,5 @@ func (e negroniEngine) Handle(pattern string, handler http.Handler) {
 
 // ServeHTTP implements the http:Handler interface from the stdlib
 func (e negroniEngine) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	e.n.ServeHTTP(w, r)
+	e.n.ServeHTTP(mux.NewHTTPErrorInterceptor(w), r)
 }

--- a/router/negroni/router_test.go
+++ b/router/negroni/router_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 )
 
 func TestDefaultFactory_ok(t *testing.T) {
@@ -174,6 +175,9 @@ func TestDefaultFactory_middlewares(t *testing.T) {
 		if resp.Header.Get("Cache-Control") != "" {
 			t.Error(endpoint.Endpoint, "Cache-Control error:", resp.Header.Get("Cache-Control"))
 		}
+		if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderCompleteResponseValue {
+			t.Error(router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
+		}
 		if resp.Header.Get("Content-Type") != "application/json" {
 			t.Error(endpoint.Endpoint, "Content-Type error:", resp.Header.Get("Content-Type"))
 		}
@@ -318,6 +322,9 @@ func checkResponseIs404(t *testing.T, req *http.Request) {
 	content := string(body)
 	if resp.Header.Get("Cache-Control") != "" {
 		t.Error("Cache-Control error:", resp.Header.Get("Cache-Control"))
+	}
+	if resp.Header.Get(router.CompleteResponseHeaderName) != router.HeaderIncompleteResponseValue {
+		t.Error(req.URL.String(), router.CompleteResponseHeaderName, "error:", resp.Header.Get(router.CompleteResponseHeaderName))
 	}
 	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Error("Content-Type error:", resp.Header.Get("Content-Type"))

--- a/router/router.go
+++ b/router/router.go
@@ -37,7 +37,14 @@ func DefaultToHTTPError(_ error) int {
 	return http.StatusInternalServerError
 }
 
+const (
+	HeaderCompleteResponseValue   = "true"
+	HeaderIncompleteResponseValue = "false"
+)
+
 var (
+	// CompleteResponseHeaderName is the header to flag incomplete responses to the client
+	CompleteResponseHeaderName = "X-KrakenD-Completed"
 	// HeadersToSend are the headers to pass from the router request to the proxy
 	HeadersToSend = []string{"Content-Type"}
 	// UserAgentHeaderValue is the value of the User-Agent header to add to the proxy request


### PR DESCRIPTION
As requested in #119 , this PR adds the `X-KrakenD-Completed: true|false` header to every response returned by the KrakenD gateway