### PR TITLE
Static partial responses

### DIFF
--- a/proxy/factory.go
+++ b/proxy/factory.go
@@ -59,6 +59,11 @@ func (pf defaultFactory) New(cfg *config.EndpointConfig) (p Proxy, err error) {
 	default:
 		p, err = pf.newMulti(cfg)
 	}
+	if err != nil {
+		return
+	}
+
+	p = NewStaticMiddleware(cfg)(p)
 	return
 }
 

--- a/proxy/stack_benchmark_test.go
+++ b/proxy/stack_benchmark_test.go
@@ -17,6 +17,19 @@ func BenchmarkProxyStack_single(b *testing.B) {
 		Method:          "GET",
 		URLPattern:      "/a/{{.Tupu}}",
 	}
+	cfg := &config.EndpointConfig{
+		Backend: []*config.Backend{backend},
+		ExtraConfig: map[string]interface{}{
+			Namespace: map[string]interface{}{
+				staticKey: map[string]interface{}{
+					"data": map[string]interface{}{
+						"status": "errored",
+					},
+				},
+				"strategy": "incomplete",
+			},
+		},
+	}
 	expected := Response{
 		Data:       map[string]interface{}{"supu": 42, "tupu": true, "foo": "bar"},
 		IsComplete: true,
@@ -26,6 +39,7 @@ func BenchmarkProxyStack_single(b *testing.B) {
 	p = NewRoundRobinLoadBalancedMiddleware(backend)(p)
 	p = NewConcurrentMiddleware(backend)(p)
 	p = NewRequestBuilderMiddleware(backend)(p)
+	p = NewStaticMiddleware(cfg)(p)
 
 	request := &Request{
 		Method:  "GET",
@@ -83,6 +97,7 @@ func BenchmarkProxyStack_multi(b *testing.B) {
 				backendProxy[i] = NewRequestBuilderMiddleware(backend)(backendProxy[i])
 			}
 			p := NewMergeDataMiddleware(cfg)(backendProxy...)
+			p = NewStaticMiddleware(cfg)(p)
 
 			b.ResetTimer()
 			b.ReportAllocs()

--- a/proxy/static.go
+++ b/proxy/static.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+// NewStaticMiddleware creates proxy middleware for adding static values to the processed responses
+func NewStaticMiddleware(endpointConfig *config.EndpointConfig) Middleware {
+	cfg, ok := getStaticMiddlewareCfg(endpointConfig.ExtraConfig)
+	if !ok {
+		return EmptyMiddleware
+	}
+	return func(next ...Proxy) Proxy {
+		if len(next) > 1 {
+			panic(ErrTooManyProxies)
+		}
+		return func(ctx context.Context, request *Request) (*Response, error) {
+			result, err := next[0](ctx, request)
+			if !cfg.Match(result, err) {
+				return result, err
+			}
+
+			if result == nil {
+				result = &Response{Data: map[string]interface{}{}}
+			}
+
+			for k, v := range cfg.Data {
+				result.Data[k] = v
+			}
+
+			return result, err
+		}
+	}
+}
+
+const (
+	staticKey = "static"
+
+	staticAlwaysStrategy       = "always"
+	staticIfSuccessStrategy    = "success"
+	staticIfErroredStrategy    = "errored"
+	staticIfCompleteStrategy   = "complete"
+	staticIfIncompleteStrategy = "incomplete"
+)
+
+type staticConfig struct {
+	Data     map[string]interface{}
+	Strategy string
+	Match    func(*Response, error) bool
+}
+
+func getStaticMiddlewareCfg(extra config.ExtraConfig) (staticConfig, bool) {
+	v, ok := extra[Namespace]
+	if !ok {
+		return staticConfig{}, ok
+	}
+	e, ok := v.(map[string]interface{})
+	if !ok {
+		return staticConfig{}, ok
+	}
+	v, ok = e[staticKey]
+	if !ok {
+		return staticConfig{}, ok
+	}
+	tmp, ok := v.(map[string]interface{})
+	if !ok {
+		return staticConfig{}, ok
+	}
+	data, ok := tmp["data"].(map[string]interface{})
+	if !ok {
+		return staticConfig{}, ok
+	}
+
+	name, ok := tmp["strategy"].(string)
+	if !ok {
+		name = staticAlwaysStrategy
+	}
+	cfg := staticConfig{
+		Data:     data,
+		Strategy: name,
+		Match:    staticAlwaysMatch,
+	}
+	switch name {
+	case staticAlwaysStrategy:
+		cfg.Match = staticAlwaysMatch
+	case staticIfSuccessStrategy:
+		cfg.Match = staticIfSuccessMatch
+	case staticIfErroredStrategy:
+		cfg.Match = staticIfErroredMatch
+	case staticIfCompleteStrategy:
+		cfg.Match = staticIfCompleteMatch
+	case staticIfIncompleteStrategy:
+		cfg.Match = staticIfIncompleteMatch
+	}
+	return cfg, true
+}
+
+func staticAlwaysMatch(_ *Response, _ error) bool       { return true }
+func staticIfSuccessMatch(_ *Response, err error) bool  { return err == nil }
+func staticIfErroredMatch(_ *Response, err error) bool  { return err != nil }
+func staticIfCompleteMatch(r *Response, err error) bool { return err == nil && r != nil && r.IsComplete }
+func staticIfIncompleteMatch(r *Response, _ error) bool { return r == nil || !r.IsComplete }

--- a/proxy/static_test.go
+++ b/proxy/static_test.go
@@ -1,0 +1,227 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+func TestNewStaticMiddleware_ok(t *testing.T) {
+	endpoint := config.EndpointConfig{
+		ExtraConfig: config.ExtraConfig{
+			Namespace: map[string]interface{}{
+				staticKey: map[string]interface{}{
+					"data": map[string]interface{}{
+						"new-1": true,
+						"new-2": map[string]interface{}{"k1": 42},
+						"new-3": "42",
+					},
+					"strategy": "incomplete",
+				},
+			},
+		},
+	}
+	mw := NewStaticMiddleware(&endpoint)
+
+	p := mw(dummyProxy(&Response{Data: map[string]interface{}{"supu": 42}, IsComplete: true}))
+	out1, err := p(context.Background(), &Request{})
+	if err != nil {
+		t.Errorf("The middleware propagated an unexpected error: %s", err.Error())
+	}
+	if out1 == nil {
+		t.Error("The proxy returned a null result")
+		return
+	}
+	if len(out1.Data) != 1 {
+		t.Errorf("We weren't expecting an extra partial response but we got %v!", out1)
+	}
+	if !out1.IsComplete {
+		t.Errorf("We were expecting a completed response but we got an incompleted one!")
+	}
+
+	p = mw(dummyProxy(&Response{Data: map[string]interface{}{"supu": 42}}))
+	out2, err := p(context.Background(), &Request{})
+	if err != nil {
+		t.Errorf("The middleware propagated an unexpected error: %s", err.Error())
+	}
+	if out2 == nil {
+		t.Error("The proxy returned a null result")
+		return
+	}
+	if len(out2.Data) != 4 {
+		t.Errorf("We weren't expecting a partial response but we got %v!", out2)
+	}
+
+	expectedError := errors.New("expect me")
+	p = mw(func(_ context.Context, _ *Request) (*Response, error) {
+		return nil, expectedError
+	})
+	out3, err := p(context.Background(), &Request{})
+	if err != expectedError {
+		t.Errorf("The middleware propagated an unexpected error: %s", err)
+	}
+	if out3 == nil {
+		t.Error("The proxy returned a null result")
+		return
+	}
+	if len(out3.Data) != 3 {
+		t.Errorf("We weren't expecting a partial response but we got %v!", out3)
+	}
+}
+
+type staticMatcherTestCase struct {
+	name     string
+	response *Response
+	err      error
+	expected bool
+}
+
+func Test_staticAlwaysMatch(t *testing.T) {
+	for _, testCase := range []staticMatcherTestCase{
+		{
+			name:     "nil & nil",
+			expected: true,
+		},
+		{
+			name:     "nil & error",
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+		{
+			name:     "complete & nil",
+			response: &Response{Data: map[string]interface{}{}, IsComplete: true},
+			expected: true,
+		},
+		{
+			name:     "complete & error",
+			response: &Response{Data: map[string]interface{}{}, IsComplete: true},
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+		{
+			name:     "incomplete",
+			response: &Response{},
+			expected: true,
+		},
+	} {
+		testStaticMatcher(t, staticAlwaysMatch, testCase)
+	}
+}
+
+func Test_staticIfSuccessMatch(t *testing.T) {
+	for _, testCase := range []staticMatcherTestCase{
+		{
+			name:     "nil & nil",
+			expected: true,
+		},
+		{
+			name:     "nil & error",
+			err:      errors.New("ignore me"),
+			expected: false,
+		},
+		{
+			name:     "success & nil",
+			response: &Response{},
+			expected: true,
+		},
+		{
+			name:     "success & error",
+			response: &Response{},
+			err:      errors.New("ignore me"),
+		},
+	} {
+		testStaticMatcher(t, staticIfSuccessMatch, testCase)
+	}
+}
+
+func Test_staticIfErroredMatch(t *testing.T) {
+	for _, testCase := range []staticMatcherTestCase{
+		{
+			name: "nil & nil",
+		},
+		{
+			name:     "nil & error",
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+		{
+			name:     "success & nil",
+			response: &Response{},
+		},
+		{
+			name:     "success & error",
+			response: &Response{},
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+	} {
+		testStaticMatcher(t, staticIfErroredMatch, testCase)
+	}
+}
+
+func Test_staticIfCompleteMatch(t *testing.T) {
+	for _, testCase := range []staticMatcherTestCase{
+		{
+			name: "nil & nil",
+		},
+		{
+			name: "nil & error",
+			err:  errors.New("ignore me"),
+		},
+		{
+			name:     "success & nil",
+			response: &Response{},
+		},
+		{
+			name:     "success & error",
+			response: &Response{},
+			err:      errors.New("ignore me"),
+		},
+		{
+			name:     "complete",
+			response: &Response{IsComplete: true},
+			expected: true,
+		},
+	} {
+		testStaticMatcher(t, staticIfCompleteMatch, testCase)
+	}
+}
+
+func Test_staticIfIncompleteMatch(t *testing.T) {
+	for _, testCase := range []staticMatcherTestCase{
+		{
+			name:     "nil & nil",
+			expected: true,
+		},
+		{
+			name:     "nil & error",
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+		{
+			name:     "success & nil",
+			response: &Response{},
+			expected: true,
+		},
+		{
+			name:     "success & error",
+			response: &Response{},
+			err:      errors.New("ignore me"),
+			expected: true,
+		},
+		{
+			name:     "complete",
+			response: &Response{IsComplete: true},
+		},
+	} {
+		testStaticMatcher(t, staticIfIncompleteMatch, testCase)
+	}
+}
+
+func testStaticMatcher(t *testing.T, marcher func(*Response, error) bool, testCase staticMatcherTestCase) {
+	if marcher(testCase.response, testCase.err) != testCase.expected {
+		t.Errorf("[%s] unexepecting match result (%v) with: %v, %v", testCase.name, testCase.expected, testCase.response, testCase.err)
+	}
+}


### PR DESCRIPTION
This PR adds 'partial responses' to the KrakenD manipulation toolbox, by injecting the content of `data` field defined at the `extra_config` using the requested `strategy`.

Configuration example:

```
...
{
    "endpoint": "/abc",
    "extra_config": {
        "github.com/devopsfaith/krakend/proxy": {
            "static": {
                "data" : {
                    "new_field_a": 42,
                    "new_field_b": ["data"],
                    "new_field_c": {"data": "b"}
                },
                "strategy": "incomplete"
            }
        }
    }
}
...
```

Available strategies:

- `always` will add the data to every response
- `success` will add the data to every non-failed response
- `errored` will add the data to every failed response (error not nil)
- `complete` will add the data to every response marked as completed
- `incomplete` will add the data to every nil response or the ones marked as incomplete

This PR does not quite address the issue #120 , but covers some of the expected features