### PR TITLE
request deep copy helpers added

### DIFF
--- a/proxy/request_test.go
+++ b/proxy/request_test.go
@@ -24,3 +24,110 @@ func TestRequestGeneratePath(t *testing.T) {
 		}
 	}
 }
+
+func TestRequest_Clone(t *testing.T) {
+	r := Request{
+		Method: "GET",
+		Params: map[string]string{
+			"Supu": "42",
+			"Tupu": "false",
+			"Foo":  "bar",
+		},
+		Headers: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+	}
+	clone := r.Clone()
+
+	if len(r.Params) != len(clone.Params) {
+		t.Errorf("wrong num of params. have: %d, want: %d", len(clone.Params), len(r.Params))
+		return
+	}
+	for k, v := range r.Params {
+		if res, ok := clone.Params[k]; !ok {
+			t.Errorf("param %s not cloned", k)
+		} else if res != v {
+			t.Errorf("unexpected param %s. have: %s, want: %s", k, res, v)
+		}
+	}
+
+	if len(r.Headers) != len(clone.Headers) {
+		t.Errorf("wrong num of headers. have: %d, want: %d", len(clone.Headers), len(r.Headers))
+		return
+	}
+
+	for k, vs := range r.Headers {
+		if res, ok := clone.Headers[k]; !ok {
+			t.Errorf("header %s not cloned", k)
+		} else if len(res) != len(vs) {
+			t.Errorf("unexpected header %s. have: %v, want: %v", k, res, vs)
+		}
+	}
+
+	r.Headers["extra"] = []string{"supu"}
+
+	if len(r.Headers) != len(clone.Headers) {
+		t.Errorf("wrong num of headers. have: %d, want: %d", len(clone.Headers), len(r.Headers))
+		return
+	}
+
+	for k, vs := range r.Headers {
+		if res, ok := clone.Headers[k]; !ok {
+			t.Errorf("header %s not cloned", k)
+		} else if len(res) != len(vs) {
+			t.Errorf("unexpected header %s. have: %v, want: %v", k, res, vs)
+		}
+	}
+}
+
+func TestCloneRequest(t *testing.T) {
+	r := Request{
+		Method: "GET",
+		Params: map[string]string{
+			"Supu": "42",
+			"Tupu": "false",
+			"Foo":  "bar",
+		},
+		Headers: map[string][]string{
+			"Content-Type": {"application/json"},
+		},
+	}
+	clone := CloneRequest(&r)
+
+	if len(r.Params) != len(clone.Params) {
+		t.Errorf("wrong num of params. have: %d, want: %d", len(clone.Params), len(r.Params))
+		return
+	}
+	for k, v := range r.Params {
+		if res, ok := clone.Params[k]; !ok {
+			t.Errorf("param %s not cloned", k)
+		} else if res != v {
+			t.Errorf("unexpected param %s. have: %s, want: %s", k, res, v)
+		}
+	}
+
+	if len(r.Headers) != len(clone.Headers) {
+		t.Errorf("wrong num of headers. have: %d, want: %d", len(clone.Headers), len(r.Headers))
+		return
+	}
+
+	for k, vs := range r.Headers {
+		if res, ok := clone.Headers[k]; !ok {
+			t.Errorf("header %s not cloned", k)
+		} else if len(res) != len(vs) {
+			t.Errorf("unexpected header %s. have: %v, want: %v", k, res, vs)
+		}
+	}
+
+	r.Headers["extra"] = []string{"supu"}
+
+	if _, ok := clone.Headers["extra"]; ok {
+		t.Error("the cloned instance shares its headers with the original one")
+	}
+
+	delete(r.Params, "Supu")
+
+	if _, ok := clone.Params["Supu"]; !ok {
+		t.Error("the cloned instance shares its params with the original one")
+	}
+}


### PR DESCRIPTION
In order to avoid race-conditions on middlewares running at the 'not thread-safe' part of the proxy pipe (see #105 ), this PR introduces 3 helpers those components could use:

- `func CloneRequest(r *Request) *Request`
- `func CloneRequestHeaders(headers map[string][]string) map[string][]string`
- `func CloneRequestParams(params map[string]string) map[string]string`

Developers must select one of them depending on what they want to change in their middleware