### PR TITLE
Private http client

### DIFF
--- a/proxy/http_executor.go
+++ b/proxy/http_executor.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 // HTTPRequestExecutor defines the interface of the request executor for the HTTP transport protocol
@@ -21,4 +22,4 @@ type HTTPClientFactory func(ctx context.Context) *http.Client
 // NewHTTPClient just returns the http default client
 func NewHTTPClient(ctx context.Context) *http.Client { return defaultHTTPClient }
 
-var defaultHTTPClient = &http.Client{}
+var defaultHTTPClient = &http.Client{Timeout: 15 * time.Second}

--- a/proxy/http_executor.go
+++ b/proxy/http_executor.go
@@ -18,5 +18,7 @@ func DefaultHTTPRequestExecutor(clientFactory HTTPClientFactory) HTTPRequestExec
 // HTTPClientFactory creates http clients based with the received context
 type HTTPClientFactory func(ctx context.Context) *http.Client
 
-// NewHTTPClient just creates a http default client
-func NewHTTPClient(_ context.Context) *http.Client { return http.DefaultClient }
+// NewHTTPClient just returns the http default client
+func NewHTTPClient(ctx context.Context) *http.Client { return defaultHTTPClient }
+
+var defaultHTTPClient = &http.Client{}


### PR DESCRIPTION
The HTTP backend factory should use its own HTTP client in order to isolate the pipes from other parts of the system (metric reporters, etc)