### PR TITLE
Decoupled http server

### DIFF
--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -23,7 +23,7 @@ type Config struct {
 	HandlerFactory HandlerFactory
 	ProxyFactory   proxy.Factory
 	Logger         logging.Logger
-	Runserver      RunServerFunc
+	RunServer      RunServerFunc
 }
 
 // DefaultFactory returns a gin router factory with the injected proxy factory and logger.
@@ -36,7 +36,7 @@ func DefaultFactory(proxyFactory proxy.Factory, logger logging.Logger) router.Fa
 			HandlerFactory: EndpointHandler,
 			ProxyFactory:   proxyFactory,
 			Logger:         logger,
-			Runserver:      router.RunServer,
+			RunServer:      router.RunServer,
 		},
 	)
 }
@@ -57,7 +57,7 @@ func (rf factory) New() router.Router {
 
 // NewWithContext implements the factory interface
 func (rf factory) NewWithContext(ctx context.Context) router.Router {
-	return ginRouter{rf.cfg, ctx, rf.cfg.Runserver}
+	return ginRouter{rf.cfg, ctx, rf.cfg.RunServer}
 }
 
 type ginRouter struct {

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -3,8 +3,6 @@ package gin
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 
@@ -87,23 +85,10 @@ func (r ginRouter) Run(cfg config.ServiceConfig) {
 		c.Header(router.CompleteResponseHeaderName, router.HeaderIncompleteResponseValue)
 	})
 
-	s := &http.Server{
-		Addr:              fmt.Sprintf(":%d", cfg.Port),
-		Handler:           r.cfg.Engine,
-		ReadTimeout:       cfg.ReadTimeout,
-		WriteTimeout:      cfg.WriteTimeout,
-		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
-		IdleTimeout:       cfg.IdleTimeout,
-	}
-
-	go func() {
-		r.cfg.Logger.Critical(s.ListenAndServe())
-	}()
-
-	<-r.ctx.Done()
-	if err := s.Shutdown(context.Background()); err != nil {
+	if err := router.RunServer(r.ctx, cfg, r.cfg.Engine); err != nil {
 		r.cfg.Logger.Error(err.Error())
 	}
+
 	r.cfg.Logger.Info("Router execution ended")
 }
 

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devopsfaith/krakend/router"
 )
 
+// RunServerFunc is a func that will run the http Server with the given params.
 type RunServerFunc func(context.Context, config.ServiceConfig, http.Handler) error
 
 // Config is the struct that collects the parts the router should be builded from

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -250,9 +250,7 @@ func TestRunServer_ko(t *testing.T) {
 	).New()
 
 	serviceCfg := config.ServiceConfig{}
-
-	go func() { r.Run(serviceCfg) }()
-	time.Sleep(5 * time.Millisecond)
+	r.Run(serviceCfg)
 	re := regexp.MustCompile(errorMsg)
 	if !re.MatchString(string(buff.Bytes())) {
 		t.Errorf("the logger doesn't contain the expected msg: %s", buff.Bytes())

--- a/router/gin/router_test.go
+++ b/router/gin/router_test.go
@@ -5,9 +5,11 @@ package gin
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
 	"github.com/devopsfaith/krakend/router"
+	"github.com/gin-gonic/gin"
 )
 
 func TestDefaultFactory_ok(t *testing.T) {
@@ -218,6 +221,41 @@ func TestDefaultFactory_proxyFactoryCrash(t *testing.T) {
 		req, _ := http.NewRequest(subject[0], fmt.Sprintf("http://127.0.0.1:8074/%s", subject[1]), nil)
 		req.Header.Set("Content-Type", "application/json")
 		checkResponseIs404(t, req)
+	}
+}
+
+func TestRunServer_ko(t *testing.T) {
+	buff := new(bytes.Buffer)
+	logger, err := logging.NewLogger("ERROR", buff, "")
+	if err != nil {
+		t.Error("building the logger:", err.Error())
+		return
+	}
+
+	errorMsg := "runServer error"
+	runServerFunc := func(_ context.Context, _ config.ServiceConfig, _ http.Handler) error {
+		return errors.New(errorMsg)
+	}
+
+	pf := noopProxyFactory(map[string]interface{}{"supu": "tupu"})
+	r := NewFactory(
+		Config{
+			Engine:         gin.Default(),
+			Middlewares:    []gin.HandlerFunc{},
+			HandlerFactory: EndpointHandler,
+			ProxyFactory:   pf,
+			Logger:         logger,
+			RunServer:      runServerFunc,
+		},
+	).New()
+
+	serviceCfg := config.ServiceConfig{}
+
+	go func() { r.Run(serviceCfg) }()
+	time.Sleep(5 * time.Millisecond)
+	re := regexp.MustCompile(errorMsg)
+	if !re.MatchString(string(buff.Bytes())) {
+		t.Errorf("the logger doesn't contain the expected msg: %s", buff.Bytes())
 	}
 }
 

--- a/router/gorilla/router.go
+++ b/router/gorilla/router.go
@@ -26,6 +26,7 @@ func DefaultConfig(pf proxy.Factory, logger logging.Logger) mux.Config {
 		ProxyFactory:   pf,
 		Logger:         logger,
 		DebugPattern:   "/__debug/{params}",
+		RunServer:      router.RunServer,
 	}
 }
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -85,7 +85,7 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 
 	r.registerKrakendEndpoints(cfg.Endpoints)
 
-	if err := router.RunServer(r.ctx, cfg, r.handler()); err != nil {
+	if err := r.RunServer(r.ctx, cfg, r.handler()); err != nil {
 		r.cfg.Logger.Error(err.Error())
 	}
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -73,7 +73,7 @@ func (rf factory) NewWithContext(ctx context.Context) router.Router {
 type httpRouter struct {
 	cfg       Config
 	ctx       context.Context
-	RunServer func(context.Context, config.ServiceConfig, http.Handler) error
+	RunServer RunServerFunc
 }
 
 // Run implements the router interface

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -3,7 +3,6 @@ package mux
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/devopsfaith/krakend/config"
@@ -81,23 +80,10 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 
 	r.registerKrakendEndpoints(cfg.Endpoints)
 
-	server := http.Server{
-		Addr:              fmt.Sprintf(":%d", cfg.Port),
-		Handler:           r.handler(),
-		ReadTimeout:       cfg.ReadTimeout,
-		WriteTimeout:      cfg.WriteTimeout,
-		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
-		IdleTimeout:       cfg.IdleTimeout,
-	}
-
-	go func() {
-		r.cfg.Logger.Critical(server.ListenAndServe())
-	}()
-
-	<-r.ctx.Done()
-	if err := server.Shutdown(context.Background()); err != nil {
+	if err := router.RunServer(r.ctx, cfg, r.handler()); err != nil {
 		r.cfg.Logger.Error(err.Error())
 	}
+
 	r.cfg.Logger.Info("Router execution ended")
 }
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -61,7 +61,7 @@ type factory struct {
 
 // New implements the factory interface
 func (rf factory) New() router.Router {
-	return httpRouter{rf.cfg, context.Background(), rf.cfg.RunServer}
+	return rf.NewWithContext(context.Background())
 }
 
 // NewWithContext implements the factory interface

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -14,6 +14,7 @@ import (
 // DefaultDebugPattern is the default pattern used to define the debug endpoint
 const DefaultDebugPattern = "/__debug/"
 
+// RunServerFunc is a func that will run the http Server with the given params.
 type RunServerFunc func(context.Context, config.ServiceConfig, http.Handler) error
 
 // Config is the struct that collects the parts the router should be builded from

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -141,6 +141,7 @@ func TestDefaultFactory_ko(t *testing.T) {
 		HandlerFactory: EndpointHandler,
 		ProxyFactory:   noopProxyFactory(map[string]interface{}{"supu": "tupu"}),
 		Logger:         logger,
+		RunServer:      router.RunServer,
 	}).NewWithContext(ctx)
 
 	serviceCfg := config.ServiceConfig{

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -257,9 +257,7 @@ func TestRunServer_ko(t *testing.T) {
 	).New()
 
 	serviceCfg := config.ServiceConfig{}
-
-	go func() { r.Run(serviceCfg) }()
-	time.Sleep(5 * time.Millisecond)
+	r.Run(serviceCfg)
 	re := regexp.MustCompile(errorMsg)
 	if !re.MatchString(string(buff.Bytes())) {
 		t.Errorf("the logger doesn't contain the expected msg: %s", buff.Bytes())

--- a/router/router.go
+++ b/router/router.go
@@ -4,6 +4,7 @@ package router
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -79,4 +80,30 @@ func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
 			TLSHandshakeTimeout:   10 * time.Second,
 		}
 	})
+}
+
+// RunServer runs a http.Server with the given handler and configuration
+func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handler) error {
+	done := make(chan error)
+	defer close(done)
+	s := &http.Server{
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           handler,
+		ReadTimeout:       cfg.ReadTimeout,
+		WriteTimeout:      cfg.WriteTimeout,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		IdleTimeout:       cfg.IdleTimeout,
+	}
+
+	go func() {
+		done <- s.ListenAndServe()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return s.Shutdown(context.Background())
+	}
+
 }

--- a/router/router.go
+++ b/router/router.go
@@ -85,7 +85,6 @@ func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
 // RunServer runs a http.Server with the given handler and configuration
 func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handler) error {
 	done := make(chan error)
-	defer close(done)
 	s := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.Port),
 		Handler:           handler,
@@ -101,6 +100,7 @@ func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handl
 
 	select {
 	case err := <-done:
+		close(done)
 		return err
 	case <-ctx.Done():
 		return s.Shutdown(context.Background())

--- a/router/router.go
+++ b/router/router.go
@@ -100,7 +100,6 @@ func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handl
 
 	select {
 	case err := <-done:
-		close(done)
 		return err
 	case <-ctx.Done():
 		return s.Shutdown(context.Background())


### PR DESCRIPTION
As requested in #143 this PR adds a `RunServer` function to the `Router` `Config` struct of each router so anyone can inject it's own http server.
It also moves the old implementation to a `RunServer` function in the `router` package to be used as default.