### PR TITLE
https enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 vendor
 server.rsa.crt
 server.rsa.key
+*.pem
 *.json
 *.yml
 *.toml
+*.dot
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ deps:
 	@echo ""
 
 test:
+	go generate ./...
 	go test -cover -race ./...
 
 benchmark:

--- a/config/config.go
+++ b/config/config.go
@@ -140,6 +140,10 @@ type ServiceConfig struct {
 	// Plugin defines the configuration for the plugin loader
 	Plugin *Plugin `mapstructure:"plugin"`
 
+	// TLS defines the configuration params for enabling TLS (HTTPS & HTTP/2) at
+	// the router layer
+	TLS *TLS `mapstructure:"tls"`
+
 	// run krakend in debug mode
 	Debug     bool
 	uriParser URIParser
@@ -215,6 +219,18 @@ type Backend struct {
 type Plugin struct {
 	Folder  string `mapstructure:"folder"`
 	Pattern string `mapstructure:"pattern"`
+}
+
+// TLS defines the configuration params for enabling TLS (HTTPS & HTTP/2) at the router layer
+type TLS struct {
+	IsDisabled               bool     `mapstructure:"disabled"`
+	PublicKey                string   `mapstructure:"public_key"`
+	PrivateKey               string   `mapstructure:"private_key"`
+	MinVersion               string   `mapstructure:"min_version"`
+	MaxVersion               string   `mapstructure:"max_version"`
+	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
+	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
+	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/parser.go
+++ b/config/parser.go
@@ -68,7 +68,8 @@ type parseableServiceConfig struct {
 	DialerFallbackDelay   string                     `json:"dialer_fallback_delay"`
 	DialerKeepAlive       string                     `json:"dialer_keep_alive"`
 	Debug                 bool
-	Plugin                *Plugin
+	Plugin                *Plugin `json:"plugin,omitempty"`
+	TLS                   *TLS    `json:"tls,omitempty"`
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
@@ -96,6 +97,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 		DialerKeepAlive:       parseDuration(p.DialerKeepAlive),
 		OutputEncoding:        p.OutputEncoding,
 		Plugin:                p.Plugin,
+		TLS:                   p.TLS,
 	}
 	if p.ExtraConfig != nil {
 		cfg.ExtraConfig = *p.ExtraConfig
@@ -161,9 +163,9 @@ type parseableBackend struct {
 
 func (p *parseableBackend) normalize() *Backend {
 	b := Backend{
-		Group:  p.Group,
-		Method: p.Method,
-		Host:   p.Host,
+		Group:                    p.Group,
+		Method:                   p.Method,
+		Host:                     p.Host,
 		HostSanitizationDisabled: p.HostSanitizationDisabled,
 		URLPattern:               p.URLPattern,
 		Blacklist:                p.Blacklist,

--- a/router/http/router.go
+++ b/router/http/router.go
@@ -130,25 +130,29 @@ func parseTLSVersion(key string) uint16 {
 }
 
 func parseCurveIDs(cfg *config.TLS) []tls.CurveID {
-	if l := len(cfg.CurvePreferences); l > 0 {
-		curves := make([]tls.CurveID, len(cfg.CurvePreferences))
-		for i := range curves {
-			curves[i] = tls.CurveID(cfg.CurvePreferences[i])
-		}
-		return curves
+	l := len(cfg.CurvePreferences)
+	if l == 0 {
+		return defaultCurves
 	}
-	return defaultCurves
+
+	curves := make([]tls.CurveID, len(cfg.CurvePreferences))
+	for i := range curves {
+		curves[i] = tls.CurveID(cfg.CurvePreferences[i])
+	}
+	return curves
 }
 
 func parseCipherSuites(cfg *config.TLS) []uint16 {
-	if l := len(cfg.CipherSuites); l > 0 {
-		cs := make([]uint16, l)
-		for i := range cs {
-			cs[i] = uint16(cfg.CipherSuites[i])
-		}
-		return cs
+	l := len(cfg.CipherSuites)
+	if l == 0 {
+		return defaultCipherSuites
 	}
-	return defaultCipherSuites
+
+	cs := make([]uint16, l)
+	for i := range cs {
+		cs[i] = uint16(cfg.CipherSuites[i])
+	}
+	return cs
 }
 
 var (

--- a/router/http/router.go
+++ b/router/http/router.go
@@ -1,0 +1,175 @@
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/core"
+)
+
+// ToHTTPError translates an error into a HTTP status code
+type ToHTTPError func(error) int
+
+// DefaultToHTTPError is a ToHTTPError transalator that always returns an
+// internal server error
+func DefaultToHTTPError(_ error) int {
+	return http.StatusInternalServerError
+}
+
+const (
+	HeaderCompleteResponseValue   = "true"
+	HeaderIncompleteResponseValue = "false"
+)
+
+var (
+	// CompleteResponseHeaderName is the header to flag incomplete responses to the client
+	CompleteResponseHeaderName = "X-KrakenD-Completed"
+	// HeadersToSend are the headers to pass from the router request to the proxy
+	HeadersToSend = []string{"Content-Type"}
+	// UserAgentHeaderValue is the value of the User-Agent header to add to the proxy request
+	UserAgentHeaderValue = []string{core.KrakendUserAgent}
+
+	// ErrInternalError is the error returned by the router when something went wrong
+	ErrInternalError = errors.New("internal server error")
+	// ErrPrivateKey is the error returned by the router when the private key is not defined
+	ErrPrivateKey = errors.New("private key not defined")
+	// ErrPublicKey is the error returned by the router when the public key is not defined
+	ErrPublicKey = errors.New("public key not defined")
+)
+
+// InitHTTPDefaultTransport ensures the default HTTP transport is configured just once per execution
+func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
+	onceTransportConfig.Do(func() {
+		http.DefaultTransport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:       cfg.DialerTimeout,
+				KeepAlive:     cfg.DialerKeepAlive,
+				FallbackDelay: cfg.DialerFallbackDelay,
+				DualStack:     true,
+			}).DialContext,
+			DisableCompression:    cfg.DisableCompression,
+			DisableKeepAlives:     cfg.DisableKeepAlives,
+			MaxIdleConns:          cfg.MaxIdleConns,
+			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+			IdleConnTimeout:       cfg.IdleConnTimeout,
+			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
+			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
+			TLSHandshakeTimeout:   10 * time.Second,
+		}
+	})
+}
+
+// RunServer runs a http.Server with the given handler and configuration.
+// It configures the TLS layer if required by the received configuration.
+func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handler) error {
+	done := make(chan error)
+	s := &http.Server{
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           handler,
+		ReadTimeout:       cfg.ReadTimeout,
+		WriteTimeout:      cfg.WriteTimeout,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+		IdleTimeout:       cfg.IdleTimeout,
+		TLSConfig:         parseTLSConfig(cfg.TLS),
+	}
+
+	if s.TLSConfig == nil {
+		go func() {
+			done <- s.ListenAndServe()
+		}()
+	} else {
+		if cfg.TLS.PublicKey == "" {
+			return ErrPublicKey
+		}
+		if cfg.TLS.PrivateKey == "" {
+			return ErrPrivateKey
+		}
+		go func() {
+			done <- s.ListenAndServeTLS(cfg.TLS.PublicKey, cfg.TLS.PrivateKey)
+		}()
+	}
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return s.Shutdown(context.Background())
+	}
+}
+
+func parseTLSConfig(cfg *config.TLS) *tls.Config {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.IsDisabled {
+		return nil
+	}
+
+	return &tls.Config{
+		MinVersion:               parseTLSVersion(cfg.MinVersion),
+		MaxVersion:               parseTLSVersion(cfg.MaxVersion),
+		CurvePreferences:         parseCurveIDs(cfg),
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		CipherSuites:             parseCipherSuites(cfg),
+	}
+}
+
+func parseTLSVersion(key string) uint16 {
+	if v, ok := versions[key]; ok {
+		return v
+	}
+	return tls.VersionTLS12
+}
+
+func parseCurveIDs(cfg *config.TLS) []tls.CurveID {
+	if l := len(cfg.CurvePreferences); l > 0 {
+		curves := make([]tls.CurveID, len(cfg.CurvePreferences))
+		for i := range curves {
+			curves[i] = tls.CurveID(cfg.CurvePreferences[i])
+		}
+		return curves
+	}
+	return defaultCurves
+}
+
+func parseCipherSuites(cfg *config.TLS) []uint16 {
+	if l := len(cfg.CipherSuites); l > 0 {
+		cs := make([]uint16, l)
+		for i := range cs {
+			cs[i] = uint16(cfg.CipherSuites[i])
+		}
+		return cs
+	}
+	return defaultCipherSuites
+}
+
+var (
+	onceTransportConfig sync.Once
+	defaultCurves       = []tls.CurveID{
+		tls.CurveP521,
+		tls.CurveP384,
+		tls.CurveP256,
+	}
+	defaultCipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}
+	versions = map[string]uint16{
+		"SSL3.0": tls.VersionSSL30,
+		"TLS10":  tls.VersionTLS10,
+		"TLS11":  tls.VersionTLS11,
+		"TLS12":  tls.VersionTLS12,
+	}
+)

--- a/router/http/router_test.go
+++ b/router/http/router_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/devopsfaith/krakend/config"
 )
 
-func TestTestRunServer_TLS(t *testing.T) {
-	test_keyAreAvailable(t)
+func TestRunServer_TLS(t *testing.T) {
+	testKeysAreAvailable(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -212,7 +212,7 @@ func dummyHandler(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "Hello, %q", html.EscapeString(req.URL.Path))
 }
 
-func test_keyAreAvailable(t *testing.T) {
+func testKeysAreAvailable(t *testing.T) {
 	files, err := ioutil.ReadDir(".")
 	if err != nil {
 		log.Fatal(err)

--- a/router/http/router_test.go
+++ b/router/http/router_test.go
@@ -1,0 +1,76 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/http"
+	"testing"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+func TestRunServer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- RunServer(
+			ctx,
+			config.ServiceConfig{Port: 9999},
+			http.HandlerFunc(dummyHandler),
+		)
+	}()
+
+	resp, err := http.Get("http://localhost:9999")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("unexpected status code: %d", resp.StatusCode)
+		return
+	}
+	cancel()
+
+	if err = <-done; err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRunServer_err(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error)
+	for _, tc := range []struct {
+		cfg *config.TLS
+		err error
+	}{
+		{
+			cfg: &config.TLS{},
+			err: ErrPublicKey,
+		},
+		{
+			cfg: &config.TLS{
+				PublicKey: "unknown",
+			},
+			err: ErrPrivateKey,
+		},
+	} {
+		go func() {
+			done <- RunServer(
+				ctx,
+				config.ServiceConfig{TLS: tc.cfg},
+				http.HandlerFunc(dummyHandler),
+			)
+		}()
+		if err := <-done; err != tc.err {
+			t.Error(err)
+		}
+	}
+}
+
+func dummyHandler(rw http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(rw, "Hello, %q", html.EscapeString(req.URL.Path))
+}

--- a/router/http/router_test.go
+++ b/router/http/router_test.go
@@ -10,6 +10,7 @@ import (
 	"html"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"testing"
 
@@ -22,12 +23,14 @@ func TestRunServer_TLS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	port := 9999 + rand.Intn(1000)
+
 	done := make(chan error)
 	go func() {
 		done <- RunServer(
 			ctx,
 			config.ServiceConfig{
-				Port: 9999,
+				Port: port,
 				TLS: &config.TLS{
 					PublicKey:  "cert.pem",
 					PrivateKey: "key.pem",
@@ -43,7 +46,7 @@ func TestRunServer_TLS(t *testing.T) {
 		return
 	}
 
-	resp, err := client.Get("https://localhost:9999")
+	resp, err := client.Get(fmt.Sprintf("https://localhost:%d", port))
 	if err != nil {
 		t.Error(err)
 		return
@@ -63,16 +66,18 @@ func TestRunServer_plain(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	port := 9999 + rand.Intn(1000)
+
 	done := make(chan error)
 	go func() {
 		done <- RunServer(
 			ctx,
-			config.ServiceConfig{Port: 9999},
+			config.ServiceConfig{Port: port},
 			http.HandlerFunc(dummyHandler),
 		)
 	}()
 
-	resp, err := http.Get("http://localhost:9999")
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d", port))
 	if err != nil {
 		t.Error(err)
 		return
@@ -93,10 +98,14 @@ func TestRunServer_disabledTLS(t *testing.T) {
 	defer cancel()
 
 	done := make(chan error)
+
+	port := 9999 + rand.Intn(1000)
+
 	go func() {
 		done <- RunServer(
 			ctx,
-			config.ServiceConfig{Port: 9999,
+			config.ServiceConfig{
+				Port: port,
 				TLS: &config.TLS{
 					IsDisabled: true,
 				}},
@@ -104,7 +113,7 @@ func TestRunServer_disabledTLS(t *testing.T) {
 		)
 	}()
 
-	resp, err := http.Get("http://localhost:9999")
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d", port))
 	if err != nil {
 		t.Error(err)
 		return

--- a/router/http/router_test.go
+++ b/router/http/router_test.go
@@ -13,9 +13,14 @@ import (
 	"math/rand"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/devopsfaith/krakend/config"
 )
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
 
 func TestRunServer_TLS(t *testing.T) {
 	testKeysAreAvailable(t)

--- a/router/router.go
+++ b/router/router.go
@@ -3,15 +3,9 @@ package router
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"net"
-	"net/http"
-	"sync"
-	"time"
 
 	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/core"
+	"github.com/devopsfaith/krakend/router/http"
 )
 
 // Router sets up the public layer exposed to the users
@@ -33,76 +27,30 @@ type Factory interface {
 }
 
 // ToHTTPError translates an error into a HTTP status code
-type ToHTTPError func(error) int
+type ToHTTPError http.ToHTTPError
 
 // DefaultToHTTPError is a ToHTTPError transalator that always returns an
 // internal server error
-func DefaultToHTTPError(_ error) int {
-	return http.StatusInternalServerError
-}
+var DefaultToHTTPError = http.DefaultToHTTPError
 
 const (
-	HeaderCompleteResponseValue   = "true"
-	HeaderIncompleteResponseValue = "false"
+	HeaderCompleteResponseValue   = http.HeaderCompleteResponseValue
+	HeaderIncompleteResponseValue = http.HeaderIncompleteResponseValue
 )
 
 var (
 	// CompleteResponseHeaderName is the header to flag incomplete responses to the client
-	CompleteResponseHeaderName = "X-KrakenD-Completed"
+	CompleteResponseHeaderName = http.CompleteResponseHeaderName
 	// HeadersToSend are the headers to pass from the router request to the proxy
-	HeadersToSend = []string{"Content-Type"}
+	HeadersToSend = http.HeadersToSend
 	// UserAgentHeaderValue is the value of the User-Agent header to add to the proxy request
-	UserAgentHeaderValue = []string{core.KrakendUserAgent}
+	UserAgentHeaderValue = http.UserAgentHeaderValue
 	// ErrInternalError is the error returned by the router when something went wrong
-	ErrInternalError = errors.New("internal server error")
-
-	onceTransportConfig sync.Once
+	ErrInternalError = http.ErrInternalError
 )
 
 // InitHTTPDefaultTransport ensures the default HTTP transport is configured just once per execution
-func InitHTTPDefaultTransport(cfg config.ServiceConfig) {
-	onceTransportConfig.Do(func() {
-		http.DefaultTransport = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:       cfg.DialerTimeout,
-				KeepAlive:     cfg.DialerKeepAlive,
-				FallbackDelay: cfg.DialerFallbackDelay,
-				DualStack:     true,
-			}).DialContext,
-			DisableCompression:    cfg.DisableCompression,
-			DisableKeepAlives:     cfg.DisableKeepAlives,
-			MaxIdleConns:          cfg.MaxIdleConns,
-			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-			IdleConnTimeout:       cfg.IdleConnTimeout,
-			ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
-			ExpectContinueTimeout: cfg.ExpectContinueTimeout,
-			TLSHandshakeTimeout:   10 * time.Second,
-		}
-	})
-}
+var InitHTTPDefaultTransport = http.InitHTTPDefaultTransport
 
 // RunServer runs a http.Server with the given handler and configuration
-func RunServer(ctx context.Context, cfg config.ServiceConfig, handler http.Handler) error {
-	done := make(chan error)
-	s := &http.Server{
-		Addr:              fmt.Sprintf(":%d", cfg.Port),
-		Handler:           handler,
-		ReadTimeout:       cfg.ReadTimeout,
-		WriteTimeout:      cfg.WriteTimeout,
-		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
-		IdleTimeout:       cfg.IdleTimeout,
-	}
-
-	go func() {
-		done <- s.ListenAndServe()
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-ctx.Done():
-		return s.Shutdown(context.Background())
-	}
-
-}
+var RunServer = http.RunServer


### PR DESCRIPTION
this PR adds:

+ the required config settings for enabling the TLS layer at the router.

+ the automatic selection of the server function to call (plain or TLS)

It also moves the http related functions, vars and constants into a dedicated package. In future releases, the interface of the `router` package could deprecate the original ones.