### PR TITLE
Fix: endpoint timeouts

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -24,14 +23,13 @@ func EndpointHandler(configuration *config.EndpointConfig, proxy proxy.Proxy) gi
 
 // CustomErrorEndpointHandler implements the HandleFactory interface
 func CustomErrorEndpointHandler(configuration *config.EndpointConfig, prxy proxy.Proxy, errF router.ToHTTPError) gin.HandlerFunc {
-	endpointTimeout := time.Duration(configuration.Timeout) * time.Millisecond
 	cacheControlHeaderValue := fmt.Sprintf("public, max-age=%d", int(configuration.CacheTTL.Seconds()))
 	isCacheEnabled := configuration.CacheTTL.Seconds() != 0
 	requestGenerator := NewRequest(configuration.HeadersToPass)
 	render := getRender(configuration)
 
 	return func(c *gin.Context) {
-		requestCtx, cancel := context.WithTimeout(c, endpointTimeout)
+		requestCtx, cancel := context.WithTimeout(c, configuration.Timeout)
 
 		c.Header(core.KrakendHeaderName, core.KrakendHeaderValue)
 

--- a/router/gin/endpoint_test.go
+++ b/router/gin/endpoint_test.go
@@ -101,7 +101,7 @@ func TestEndpointHandler_cancel(t *testing.T) {
 }
 
 func TestEndpointHandler_noop(t *testing.T) {
-	testEndpointHandler(t, 10, proxy.NoopProxy, "{}", "", "application/json; charset=utf-8", http.StatusOK, false)
+	testEndpointHandler(t, time.Minute, proxy.NoopProxy, "{}", "", "application/json; charset=utf-8", http.StatusOK, false)
 }
 
 func testEndpointHandler(t *testing.T, timeout time.Duration, p proxy.Proxy, expectedBody, expectedCache,

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/core"
@@ -27,7 +26,6 @@ func CustomEndpointHandler(rb RequestBuilder) HandlerFactory {
 // CustomEndpointHandlerWithHTTPError returns a HandlerFactory with the received RequestBuilder
 func CustomEndpointHandlerWithHTTPError(rb RequestBuilder, errF router.ToHTTPError) HandlerFactory {
 	return func(configuration *config.EndpointConfig, prxy proxy.Proxy) http.HandlerFunc {
-		endpointTimeout := time.Duration(configuration.Timeout) * time.Millisecond
 		cacheControlHeaderValue := fmt.Sprintf("public, max-age=%d", int(configuration.CacheTTL.Seconds()))
 		isCacheEnabled := configuration.CacheTTL.Seconds() != 0
 		render := getRender(configuration)
@@ -45,7 +43,7 @@ func CustomEndpointHandlerWithHTTPError(rb RequestBuilder, errF router.ToHTTPErr
 				return
 			}
 
-			requestCtx, cancel := context.WithTimeout(context.Background(), endpointTimeout)
+			requestCtx, cancel := context.WithTimeout(context.Background(), configuration.Timeout)
 
 			response, err := prxy(requestCtx, rb(r, configuration.QueryString, headersToSend))
 

--- a/router/mux/endpoint_test.go
+++ b/router/mux/endpoint_test.go
@@ -87,7 +87,7 @@ func TestEndpointHandler_cancelEmpty(t *testing.T) {
 }
 
 func TestEndpointHandler_noop(t *testing.T) {
-	testEndpointHandler(t, 10, proxy.NoopProxy, "GET", "{}", "", "application/json", http.StatusOK, false)
+	testEndpointHandler(t, time.Minute, proxy.NoopProxy, "GET", "{}", "", "application/json", http.StatusOK, false)
 	time.Sleep(5 * time.Millisecond)
 }
 


### PR DESCRIPTION
endpoint timeouts should be durations, so no op is required