### PR TITLE
http transport package added

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -2,18 +2,14 @@ package proxy
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
+	"github.com/devopsfaith/krakend/transport/http/client"
 )
 
-// ErrInvalidStatusCode is the error returned by the http proxy when the received status code
-// is not a 200 nor a 201
-var ErrInvalidStatusCode = errors.New("Invalid status code")
-
-var httpProxy = CustomHTTPProxyFactory(NewHTTPClient)
+var httpProxy = CustomHTTPProxyFactory(client.NewHTTPClient)
 
 // HTTPProxyFactory returns a BackendFactory. The Proxies it creates will use the received net/http.Client
 func HTTPProxyFactory(client *http.Client) BackendFactory {
@@ -21,30 +17,30 @@ func HTTPProxyFactory(client *http.Client) BackendFactory {
 }
 
 // CustomHTTPProxyFactory returns a BackendFactory. The Proxies it creates will use the received HTTPClientFactory
-func CustomHTTPProxyFactory(cf HTTPClientFactory) BackendFactory {
+func CustomHTTPProxyFactory(cf client.HTTPClientFactory) BackendFactory {
 	return func(backend *config.Backend) Proxy {
 		return NewHTTPProxy(backend, cf, backend.Decoder)
 	}
 }
 
 // NewHTTPProxy creates a http proxy with the injected configuration, HTTPClientFactory and Decoder
-func NewHTTPProxy(remote *config.Backend, clientFactory HTTPClientFactory, decode encoding.Decoder) Proxy {
-	return NewHTTPProxyWithHTTPExecutor(remote, DefaultHTTPRequestExecutor(clientFactory), decode)
+func NewHTTPProxy(remote *config.Backend, cf client.HTTPClientFactory, decode encoding.Decoder) Proxy {
+	return NewHTTPProxyWithHTTPExecutor(remote, client.DefaultHTTPRequestExecutor(cf), decode)
 }
 
 // NewHTTPProxyWithHTTPExecutor creates a http proxy with the injected configuration, HTTPRequestExecutor and Decoder
-func NewHTTPProxyWithHTTPExecutor(remote *config.Backend, requestExecutor HTTPRequestExecutor, dec encoding.Decoder) Proxy {
+func NewHTTPProxyWithHTTPExecutor(remote *config.Backend, re client.HTTPRequestExecutor, dec encoding.Decoder) Proxy {
 	if remote.Encoding == encoding.NOOP {
-		return NewHTTPProxyDetailed(remote, requestExecutor, NoOpHTTPStatusHandler, NoOpHTTPResponseParser)
+		return NewHTTPProxyDetailed(remote, re, client.NoOpHTTPStatusHandler, NoOpHTTPResponseParser)
 	}
 
 	ef := NewEntityFormatter(remote)
 	rp := DefaultHTTPResponseParserFactory(HTTPResponseParserConfig{dec, ef})
-	return NewHTTPProxyDetailed(remote, requestExecutor, DefaultHTTPStatusHandler, rp)
+	return NewHTTPProxyDetailed(remote, re, client.DefaultHTTPStatusHandler, rp)
 }
 
 // NewHTTPProxyDetailed creates a http proxy with the injected configuration, HTTPRequestExecutor, Decoder and HTTPResponseParser
-func NewHTTPProxyDetailed(remote *config.Backend, requestExecutor HTTPRequestExecutor, ch HTTPStatusHandler, rp HTTPResponseParser) Proxy {
+func NewHTTPProxyDetailed(remote *config.Backend, re client.HTTPRequestExecutor, ch client.HTTPStatusHandler, rp HTTPResponseParser) Proxy {
 	return func(ctx context.Context, request *Request) (*Response, error) {
 		requestToBakend, err := http.NewRequest(request.Method, request.URL.String(), request.Body)
 		if err != nil {
@@ -57,7 +53,7 @@ func NewHTTPProxyDetailed(remote *config.Backend, requestExecutor HTTPRequestExe
 			requestToBakend.Header[k] = tmp
 		}
 
-		resp, err := requestExecutor(ctx, requestToBakend)
+		resp, err := re(ctx, requestToBakend)
 		requestToBakend.Body.Close()
 		select {
 		case <-ctx.Done():

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/encoding"
+	"github.com/devopsfaith/krakend/transport/http/client"
 )
 
 func TestNewHTTPProxy_ok(t *testing.T) {
@@ -179,7 +180,7 @@ func TestNewHTTPProxy_badStatusCode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10)*time.Millisecond)
 	defer cancel()
 	response, err := httpProxy(&backend)(ctx, &request)
-	if err == nil || err != ErrInvalidStatusCode {
+	if err == nil || err != client.ErrInvalidStatusCode {
 		t.Errorf("The proxy didn't propagate the backend error: %s\n", err)
 	}
 	if response != nil {

--- a/router/router.go
+++ b/router/router.go
@@ -5,7 +5,7 @@ import (
 	"context"
 
 	"github.com/devopsfaith/krakend/config"
-	"github.com/devopsfaith/krakend/router/http"
+	http "github.com/devopsfaith/krakend/transport/http/server"
 )
 
 // Router sets up the public layer exposed to the users

--- a/transport/http/client/executor.go
+++ b/transport/http/client/executor.go
@@ -1,4 +1,4 @@
-package proxy
+package client
 
 import (
 	"context"

--- a/transport/http/client/status.go
+++ b/transport/http/client/status.go
@@ -1,9 +1,14 @@
-package proxy
+package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
+
+// ErrInvalidStatusCode is the error returned by the http proxy when the received status code
+// is not a 200 nor a 201
+var ErrInvalidStatusCode = errors.New("Invalid status code")
 
 // HTTPStatusHandler defines how we tread the http response code
 type HTTPStatusHandler func(context.Context, *http.Response) (*http.Response, error)

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -1,4 +1,4 @@
-package http
+package server
 
 import (
 	"context"

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -1,5 +1,5 @@
 //go:generate go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 1024 --host 127.0.0.1,::1,localhost --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
-package http
+package server
 
 import (
 	"context"


### PR DESCRIPTION
This PR introduces a new package `transport` so the related stuff won't pollute the `proxy` and the `router` packages.