### PR TITLE
Add a Hash to the service configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -210,7 +210,7 @@ type Backend struct {
 	// timeout of this backend
 	Timeout time.Duration
 	// decoder to use in order to parse the received response from the API
-	Decoder encoding.Decoder
+	Decoder encoding.Decoder `json:"-"`
 	// Backend Extra configuration for customized behaviours
 	ExtraConfig ExtraConfig `mapstructure:"extra_config"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,9 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -256,6 +259,15 @@ var (
 	errInvalidNoOpEncoding = errors.New("can not use NoOp encoding with more than one backends connected to the same endpoint")
 	defaultPort            = 8080
 )
+
+func (s *ServiceConfig) Hash() (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return base64.StdEncoding.EncodeToString(sum[:]), nil
+}
 
 // Init initializes the configuration struct and its defined endpoints and backends.
 // Init also sanitizes the values, applies the default ones whenever necessary and

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -188,6 +188,15 @@ func TestConfig_init(t *testing.T) {
 	if userEndpoint.CacheTTL != subject.CacheTTL {
 		t.Error("default CacheTTL not applied to the userEndpoint")
 	}
+
+	hash, err := subject.Hash()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if hash != "Gs5PSt/5CG3jHUvnz8t1AH1IC/czFU4c3ycBoMSs3KA=" {
+		t.Errorf("unexpected hash: %s", hash)
+	}
 }
 
 func TestConfig_initKONoBackends(t *testing.T) {


### PR DESCRIPTION
...so a fingerprint of the config can be used in other parts of the framework without passing the config itself