### PR TITLE
Support mixing optional and mandatory querystring

### DIFF
--- a/proxy/balancing.go
+++ b/proxy/balancing.go
@@ -53,7 +53,7 @@ func newLoadBalancedMiddleware(lb sd.Balancer) Middleware {
 				return nil, err
 			}
 			if len(r.Query) > 0 {
-				r.URL.RawQuery = r.Query.Encode()
+				r.URL.RawQuery += "&" + r.Query.Encode()
 			}
 
 			return next[0](ctx, &r)

--- a/proxy/request.go
+++ b/proxy/request.go
@@ -32,6 +32,10 @@ func (r *Request) GeneratePath(URLPattern string) {
 		buff = bytes.Replace(buff, key, []byte(v), -1)
 	}
 	r.Path = string(buff)
+	parsedPath, err := url.Parse(r.Path)
+	if err != nil {
+		r.Query = parsedPath.Query()
+	}
 }
 
 // Clone clones itself into a new request. The returned cloned request is not


### PR DESCRIPTION
Hi,

   I had an unexpected or inconsistent behavior in the next config:
```
....
  "endpoints": [
    {
      "endpoint": "/v3/channel/{channel}/media",
....
      "querystring_params": [
        "createdAt",
        "limit"
      ],
      "backend": [
        {
          "url_pattern": "/api/media?channel={channel}",
          "encoding": "json",
          "extra_config": {},
....
```
If I delete querystring_params from that config 'url_pattern' keeps ?channel={channel} but if I don't, the querystring is replaced completely by the allowed 'querystring_params' from the endpoint url. This patch merge querystring from url_pattern and querystring_params from the endpoint.