### PR TITLE
Endpoint option: forward all query string params and headers, if need…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,10 +169,14 @@ type EndpointConfig struct {
 	CacheTTL time.Duration `mapstructure:"cache_ttl"`
 	// list of query string params to be extracted from the URI
 	QueryString []string `mapstructure:"querystring_params"`
+	// PassAllQueryString, if true, all querystring params will be passed to backends
+	PassAllQueryString bool `mapstructure:"pass_all_querystring"`
 	// Endpoint Extra configuration for customized behaviour
 	ExtraConfig ExtraConfig `mapstructure:"extra_config"`
 	// HeadersToPass defines the list of headers to pass to the backends
 	HeadersToPass []string `mapstructure:"headers_to_pass"`
+	// PassAllHeaders, if true, all headers will be passed to backends
+	PassAllHeaders bool `mapstructure:"pass_all_headers"`
 	// OutputEncoding defines the encoding strategy to use for the endpoint responses
 	OutputEncoding string `mapstructure:"output_encoding"`
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -121,28 +121,32 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 }
 
 type parseableEndpointConfig struct {
-	Endpoint        string              `json:"endpoint"`
-	Method          string              `json:"method"`
-	Backend         []*parseableBackend `json:"backend"`
-	ConcurrentCalls int                 `json:"concurrent_calls"`
-	Timeout         string              `json:"timeout"`
-	CacheTTL        int                 `json:"cache_ttl"`
-	QueryString     []string            `json:"querystring_params"`
-	ExtraConfig     *ExtraConfig        `json:"extra_config,omitempty"`
-	HeadersToPass   []string            `json:"headers_to_pass"`
-	OutputEncoding  string              `json:"output_encoding"`
+	Endpoint           string              `json:"endpoint"`
+	Method             string              `json:"method"`
+	Backend            []*parseableBackend `json:"backend"`
+	ConcurrentCalls    int                 `json:"concurrent_calls"`
+	Timeout            string              `json:"timeout"`
+	CacheTTL           int                 `json:"cache_ttl"`
+	QueryString        []string            `json:"querystring_params"`
+	PassAllQueryString bool                `json:"pass_all_querystring"`
+	ExtraConfig        *ExtraConfig        `json:"extra_config,omitempty"`
+	HeadersToPass      []string            `json:"headers_to_pass"`
+	PassAllHeaders     bool                `json:"pass_all_headers"`
+	OutputEncoding     string              `json:"output_encoding"`
 }
 
 func (p *parseableEndpointConfig) normalize() *EndpointConfig {
 	e := EndpointConfig{
-		Endpoint:        p.Endpoint,
-		Method:          p.Method,
-		ConcurrentCalls: p.ConcurrentCalls,
-		Timeout:         parseDuration(p.Timeout),
-		CacheTTL:        time.Duration(p.CacheTTL) * time.Second,
-		QueryString:     p.QueryString,
-		HeadersToPass:   p.HeadersToPass,
-		OutputEncoding:  p.OutputEncoding,
+		Endpoint:           p.Endpoint,
+		Method:             p.Method,
+		ConcurrentCalls:    p.ConcurrentCalls,
+		Timeout:            parseDuration(p.Timeout),
+		CacheTTL:           time.Duration(p.CacheTTL) * time.Second,
+		QueryString:        p.QueryString,
+		PassAllQueryString: p.PassAllQueryString,
+		HeadersToPass:      p.HeadersToPass,
+		PassAllHeaders:     p.PassAllHeaders,
+		OutputEncoding:     p.OutputEncoding,
 	}
 	if p.ExtraConfig != nil {
 		e.ExtraConfig = *p.ExtraConfig


### PR DESCRIPTION
…ed #174

This commits adds 2 new endpoint config fields:
	pass_all_headers - when true, krakend will pass all incoming headers to backends
	pass_all_querystring - when true, krakend will pass all querystring params to backends
gin router modification