### PR TITLE
support HTTP methods in gorilla, mux & negroni

### DIFF
--- a/router/gorilla/router.go
+++ b/router/gorilla/router.go
@@ -43,7 +43,7 @@ type gorillaEngine struct {
 }
 
 // Handle implements the mux.Engine interface from the krakend router package
-func (g gorillaEngine) Handle(pattern string, handler http.Handler) {
+func (g gorillaEngine) Handle(pattern, method string, handler http.Handler) {
 	g.r.Handle(pattern, handler)
 }
 

--- a/router/gorilla/router.go
+++ b/router/gorilla/router.go
@@ -44,7 +44,7 @@ type gorillaEngine struct {
 
 // Handle implements the mux.Engine interface from the krakend router package
 func (g gorillaEngine) Handle(pattern, method string, handler http.Handler) {
-	g.r.Handle(pattern, handler)
+	g.r.Handle(pattern, handler).Methods(method)
 }
 
 // ServeHTTP implements the http:Handler interface from the stdlib

--- a/router/mux/engine.go
+++ b/router/mux/engine.go
@@ -11,7 +11,7 @@ import (
 // Engine defines the minimun required interface for the mux compatible engine
 type Engine interface {
 	http.Handler
-	Handle(pattern string, handler http.Handler)
+	Handle(pattern, method string, handler http.Handler)
 }
 
 // DefaultEngine returns a new engine using a slightly customized http.ServeMux router
@@ -23,8 +23,8 @@ type engine struct {
 	handler Engine
 }
 
-func (e *engine) Handle(pattern string, handler http.Handler) {
-	e.handler.Handle(pattern, handler)
+func (e *engine) Handle(pattern, method string, handler http.Handler) {
+	e.handler.Handle(pattern, method, handler)
 }
 
 func (e *engine) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/router/mux/engine.go
+++ b/router/mux/engine.go
@@ -16,7 +16,7 @@ type Engine interface {
 
 // DefaultEngine returns a new engine using a slightly customized http.ServeMux router
 func DefaultEngine() *engine {
-	return &engine{http.NewServeMux()}
+	return &engine{NewHandler()}
 }
 
 type engine struct {
@@ -47,4 +47,14 @@ func (i *HTTPErrorInterceptor) WriteHeader(code int) {
 		}
 	})
 	i.ResponseWriter.WriteHeader(code)
+}
+
+type Handler struct {
+	*http.ServeMux
+}
+
+func NewHandler() *Handler { return &Handler{http.NewServeMux()} }
+
+func (e *Handler) Handle(pattern, method string, handler http.Handler) {
+	e.ServeMux.Handle(pattern, handler)
 }

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -80,7 +80,7 @@ type httpRouter struct {
 // Run implements the router interface
 func (r httpRouter) Run(cfg config.ServiceConfig) {
 	if cfg.Debug {
-		r.cfg.Engine.Handle(r.cfg.DebugPattern, DebugHandler(r.cfg.Logger))
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, "GET", DebugHandler(r.cfg.Logger))
 	}
 
 	router.InitHTTPDefaultTransport(cfg)
@@ -124,7 +124,7 @@ func (r httpRouter) registerKrakendEndpoint(method, path string, handler http.Ha
 		return
 	}
 	r.cfg.Logger.Debug("registering the endpoint", method, path)
-	r.cfg.Engine.Handle(path, handler)
+	r.cfg.Engine.Handle(path, method, handler)
 }
 
 func (r httpRouter) handler() http.Handler {

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -80,7 +80,12 @@ type httpRouter struct {
 // Run implements the router interface
 func (r httpRouter) Run(cfg config.ServiceConfig) {
 	if cfg.Debug {
-		r.cfg.Engine.Handle(r.cfg.DebugPattern, "GET", DebugHandler(r.cfg.Logger))
+		debugHandler := DebugHandler(r.cfg.Logger)
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, http.MethodGet, debugHandler)
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, http.MethodPost, debugHandler)
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, http.MethodPut, debugHandler)
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, http.MethodPatch, debugHandler)
+		r.cfg.Engine.Handle(r.cfg.DebugPattern, http.MethodDelete, debugHandler)
 	}
 
 	router.InitHTTPDefaultTransport(cfg)

--- a/router/mux/router_test.go
+++ b/router/mux/router_test.go
@@ -49,6 +49,14 @@ func TestDefaultFactory_ok(t *testing.T) {
 				},
 			},
 			{
+				Endpoint: "/get",
+				Method:   "POST",
+				Timeout:  10,
+				Backend: []*config.Backend{
+					{},
+				},
+			},
+			{
 				Endpoint: "/post",
 				Method:   "Post",
 				Timeout:  10,

--- a/router/negroni/router.go
+++ b/router/negroni/router.go
@@ -53,8 +53,8 @@ type negroniEngine struct {
 }
 
 // Handle implements the mux.Engine interface from the krakend router package
-func (e negroniEngine) Handle(pattern string, handler http.Handler) {
-	e.r.Handle(pattern, handler)
+func (e negroniEngine) Handle(pattern, method string, handler http.Handler) {
+	e.r.Handle(pattern, handler).Methods(method)
 }
 
 // ServeHTTP implements the http:Handler interface from the stdlib


### PR DESCRIPTION
func Handle(pattern string, handler http.Handler)
not support method
& in my realisation of router i can not using two endpoint with different access methods