### PR TITLE
gin request header retrieval by canonical MIME

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"net/textproto"
 	"context"
 	"fmt"
 	"strings"
@@ -96,7 +97,7 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 		headers["User-Agent"] = router.UserAgentHeaderValue
 
 		for _, k := range headersToSend {
-			if h, ok := c.Request.Header[k]; ok {
+			if h, ok := c.Request.Header[textproto.CanonicalMIMEHeaderKey(k)]; ok {
 				headers[k] = h
 			}
 		}


### PR DESCRIPTION
This is a pull request based on this issue: https://github.com/devopsfaith/krakend/issues/176
The idea is to solve the problem of having headers that are written in non camel case typing not being captured by the proxy and, therefore, not being sent along with the request.