### PR TITLE
Endpoint option: forward all query string params and headers, if needed

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -95,8 +95,6 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 		}
 
 		headers := make(map[string][]string, 2+len(headersToSend))
-		headers["X-Forwarded-For"] = []string{c.ClientIP()}
-		headers["User-Agent"] = router.UserAgentHeaderValue
 
 		for _, k := range headersToSend {
 			if k == requestParamsAsterisk {
@@ -109,6 +107,8 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 				headers[k] = h
 			}
 		}
+		headers["X-Forwarded-For"] = []string{c.ClientIP()}
+		headers["User-Agent"] = router.UserAgentHeaderValue
 
 		query := make(map[string][]string, len(queryString))
 		queryValues := c.Request.URL.Query()

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -14,6 +14,8 @@ import (
 	"github.com/devopsfaith/krakend/router"
 )
 
+const requestParamsAsterisk string = "*"
+
 // HandlerFactory creates a handler function that adapts the gin router with the injected proxy
 type HandlerFactory func(*config.EndpointConfig, proxy.Proxy) gin.HandlerFunc
 
@@ -97,6 +99,12 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 		headers["User-Agent"] = router.UserAgentHeaderValue
 
 		for _, k := range headersToSend {
+			if k == requestParamsAsterisk {
+				headers = c.Request.Header
+
+				break
+			}
+
 			if h, ok := c.Request.Header[textproto.CanonicalMIMEHeaderKey(k)]; ok {
 				headers[k] = h
 			}
@@ -105,6 +113,12 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 		query := make(map[string][]string, len(queryString))
 		queryValues := c.Request.URL.Query()
 		for i := range queryString {
+			if queryString[i] == requestParamsAsterisk {
+				query = c.Request.URL.Query()
+
+				break
+			}
+
 			if v, ok := queryValues[queryString[i]]; ok && len(v) > 0 {
 				query[queryString[i]] = v
 			}


### PR DESCRIPTION
 #174

This commit changes behavior on 2 config fields:
	"querystring_params": ["*"],
	"headers_to_pass": ["*"],
Asterisk makes sending all params (headers or query string)
gin router modification