### PR TITLE
Shadow backends

### DIFF
--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -65,8 +65,7 @@ func ShadowMiddleware(next ...Proxy) Proxy {
 // the response of p2
 func NewShadowProxy(p1, p2 Proxy) Proxy {
 	return func(ctx context.Context, request *Request) (*Response, error) {
-		reqShadow := request.Clone()
-		p2(ctx, &reqShadow)
+		go p2(ctx, CloneRequest(request))
 		return p1(ctx, request)
 	}
 }

--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+type shadowFactory struct {
+	f Factory
+}
+
+// New check the Backends for an ExtraConfig with the "shadow" param to true
+// implements the Factory interface
+func (s shadowFactory) New(cfg *config.EndpointConfig) (p Proxy, err error) {
+	if len(cfg.Backend) == 0 {
+		err = ErrNoBackends
+		return
+	}
+
+	shadow := []*config.Backend{}
+	regular := []*config.Backend{}
+
+	for _, b := range cfg.Backend {
+		if isShadowBackend(b) {
+			shadow = append(shadow, b)
+			continue
+		}
+		regular = append(regular, b)
+	}
+
+	cfg.Backend = regular
+
+	p, err = s.f.New(cfg)
+
+	if len(shadow) > 0 {
+		cfg.Backend = shadow
+		pShadow, _ := s.f.New(cfg)
+		p = ShadowMiddleware(p, pShadow)
+	}
+
+	return
+}
+
+// NewShadowFactory creates a new shadowFactory using the provided Factory
+func NewShadowFactory(f Factory) Factory {
+	return shadowFactory{f}
+}
+
+// ShadowMiddleware is a Middleware that creates a shadowProxy
+func ShadowMiddleware(next ...Proxy) Proxy {
+	switch len(next) {
+	case 0:
+		panic(ErrNotEnoughProxies)
+	case 1:
+		return next[0]
+	case 2:
+		return NewShadowProxy(next[0], next[1])
+	default:
+		panic(ErrTooManyProxies)
+	}
+}
+
+// NewShadowProxy returns a Proxy that sends requests to p1 and p2 but ignores
+// the response of p2
+func NewShadowProxy(p1, p2 Proxy) Proxy {
+	return func(ctx context.Context, request *Request) (*Response, error) {
+		reqShadow := request.Clone()
+		p2(ctx, &reqShadow)
+		return p1(ctx, request)
+	}
+}
+
+func isShadowBackend(c *config.Backend) bool {
+	if v, ok := c.ExtraConfig["shadow"]; ok {
+		if s, ok := v.(bool); ok {
+			if s {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -6,6 +6,10 @@ import (
 	"github.com/devopsfaith/krakend/config"
 )
 
+const (
+	shadowKey = "shadow"
+)
+
 type shadowFactory struct {
 	f Factory
 }
@@ -71,7 +75,7 @@ func NewShadowProxy(p1, p2 Proxy) Proxy {
 }
 
 func isShadowBackend(c *config.Backend) bool {
-	if v, ok := c.ExtraConfig["shadow"]; ok {
+	if v, ok := c.ExtraConfig[shadowKey]; ok {
 		if s, ok := v.(bool); ok {
 			if s {
 				return true

--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -69,7 +69,7 @@ func ShadowMiddleware(next ...Proxy) Proxy {
 // the response of p2
 func NewShadowProxy(p1, p2 Proxy) Proxy {
 	return func(ctx context.Context, request *Request) (*Response, error) {
-		go p2(ctx, CloneRequest(request))
+		go p2(newcontextWrapper(ctx), CloneRequest(request))
 		return p1(ctx, request)
 	}
 }
@@ -83,4 +83,20 @@ func isShadowBackend(c *config.Backend) bool {
 		}
 	}
 	return false
+}
+
+type contextWrapper struct {
+	context.Context
+	data context.Context
+}
+
+func (c contextWrapper) Value(key interface{}) interface{} {
+	return c.data.Value(key)
+}
+
+func newcontextWrapper(data context.Context) contextWrapper {
+	return contextWrapper{
+		Context: context.Background(),
+		data:    data,
+	}
 }

--- a/proxy/shadow_test.go
+++ b/proxy/shadow_test.go
@@ -64,7 +64,7 @@ func TestShadowFactory_noBackends(t *testing.T) {
 	}
 	factory := DefaultFactory(logger)
 
-	sFactory := shadowFactory{factory}
+	sFactory := NewShadowFactory(factory)
 
 	if _, err := sFactory.New(&config.EndpointConfig{}); err != ErrNoBackends {
 		t.Errorf("Expecting ErrNoBackends. Got: %v\n", err)

--- a/proxy/shadow_test.go
+++ b/proxy/shadow_test.go
@@ -26,6 +26,7 @@ func newAssertionProxy(counter *uint64) Proxy {
 		return nil, nil
 	}
 }
+
 func TestIsShadowBackend(t *testing.T) {
 
 	cfg := &config.Backend{ExtraConfig: extraCfg}
@@ -50,6 +51,7 @@ func TestShadowMiddleware(t *testing.T) {
 	p := ShadowMiddleware(assertProxy, assertProxy)
 	request := &Request{}
 	p(context.Background(), request)
+	time.Sleep(100 * time.Millisecond)
 	if counter != 2 {
 		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
 	}
@@ -104,6 +106,7 @@ func TestNewShadowFactory(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	time.Sleep(100 * time.Millisecond)
 	if counter != 2 {
 		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
 	}

--- a/proxy/shadow_test.go
+++ b/proxy/shadow_test.go
@@ -52,7 +52,7 @@ func TestShadowMiddleware(t *testing.T) {
 	request := &Request{}
 	p(context.Background(), request)
 	time.Sleep(100 * time.Millisecond)
-	if counter != 2 {
+	if atomic.LoadUint64(&counter) != 2 {
 		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
 	}
 }
@@ -107,7 +107,7 @@ func TestNewShadowFactory(t *testing.T) {
 		t.Error(err)
 	}
 	time.Sleep(100 * time.Millisecond)
-	if counter != 2 {
+	if atomic.LoadUint64(&counter) != 2 {
 		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
 	}
 }

--- a/proxy/shadow_test.go
+++ b/proxy/shadow_test.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/logging"
+)
+
+var (
+	extraCfg = config.ExtraConfig{
+		"shadow": true,
+	}
+	badExtra = config.ExtraConfig{
+		"shadow": "string",
+	}
+)
+
+func newAssertionProxy(counter *uint64) Proxy {
+	return func(ctx context.Context, request *Request) (*Response, error) {
+		atomic.AddUint64(counter, 1)
+		return nil, nil
+	}
+}
+func TestIsShadowBackend(t *testing.T) {
+
+	cfg := &config.Backend{ExtraConfig: extraCfg}
+	badCfg := &config.Backend{ExtraConfig: badExtra}
+
+	if !isShadowBackend(cfg) {
+		t.Error("The shadow backend should be true")
+	}
+
+	if isShadowBackend(&config.Backend{}) {
+		t.Error("The shadow backend should be false")
+	}
+
+	if isShadowBackend(badCfg) {
+		t.Error("The shadow backend should be false")
+	}
+}
+
+func TestShadowMiddleware(t *testing.T) {
+	var counter uint64
+	assertProxy := newAssertionProxy(&counter)
+	p := ShadowMiddleware(assertProxy, assertProxy)
+	request := &Request{}
+	p(context.Background(), request)
+	if counter != 2 {
+		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
+	}
+}
+
+func TestShadowFactory_noBackends(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	logger, err := logging.NewLogger("ERROR", buff, "pref")
+	if err != nil {
+		t.Error("building the logger:", err.Error())
+		return
+	}
+	factory := DefaultFactory(logger)
+
+	sFactory := shadowFactory{factory}
+
+	if _, err := sFactory.New(&config.EndpointConfig{}); err != ErrNoBackends {
+		t.Errorf("Expecting ErrNoBackends. Got: %v\n", err)
+	}
+}
+
+func TestNewShadowFactory(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	logger, err := logging.NewLogger("ERROR", buff, "pref")
+	if err != nil {
+		t.Error("building the logger:", err.Error())
+		return
+	}
+	var counter uint64
+	assertProxy := newAssertionProxy(&counter)
+	factory := NewDefaultFactory(func(_ *config.Backend) Proxy { return assertProxy }, logger)
+	f := NewShadowFactory(factory)
+	sBackend := &config.Backend{ExtraConfig: extraCfg}
+	backend := &config.Backend{}
+	endpointConfig := &config.EndpointConfig{Backend: []*config.Backend{sBackend, backend}}
+	serviceConfig := config.ServiceConfig{
+		Version:   config.ConfigVersion,
+		Endpoints: []*config.EndpointConfig{endpointConfig},
+		Timeout:   100 * time.Millisecond,
+		Host:      []string{"dummy"},
+	}
+	if err = serviceConfig.Init(); err != nil {
+		t.Errorf("Error during the config init: %s\n", err.Error())
+	}
+
+	p, err := f.New(endpointConfig)
+	if err != nil {
+		t.Error(err)
+	}
+	request := &Request{}
+	_, err = p(context.Background(), request)
+	if err != nil {
+		t.Error(err)
+	}
+	if counter != 2 {
+		t.Errorf("The shadow proxy should have been called 2 times, not %d", counter)
+	}
+}


### PR DESCRIPTION
Adds a shadow proxy to be able to call shadow requests as requested in #130 
It looks in the `config.Backend` extra config for the "shadow" key to process the backend as shadow.