### PR TITLE
shadow extra config added to the proxy namespace

### DIFF
--- a/proxy/shadow.go
+++ b/proxy/shadow.go
@@ -75,10 +75,11 @@ func NewShadowProxy(p1, p2 Proxy) Proxy {
 }
 
 func isShadowBackend(c *config.Backend) bool {
-	if v, ok := c.ExtraConfig[shadowKey]; ok {
-		if s, ok := v.(bool); ok {
-			if s {
-				return true
+	if v, ok := c.ExtraConfig[Namespace]; ok {
+		if e, ok := v.(map[string]interface{}); ok {
+			if v, ok := e[shadowKey]; ok {
+				c, ok := v.(bool)
+				return ok && c
 			}
 		}
 	}

--- a/proxy/shadow_test.go
+++ b/proxy/shadow_test.go
@@ -14,10 +14,14 @@ import (
 
 var (
 	extraCfg = config.ExtraConfig{
-		"shadow": true,
+		Namespace: map[string]interface{}{
+			"shadow": true,
+		},
 	}
 	badExtra = config.ExtraConfig{
-		"shadow": "string",
+		Namespace: map[string]interface{}{
+			"shadow": "string",
+		},
 	}
 )
 


### PR DESCRIPTION
so, a shadow backend is defined as:

```
...
{
    "endpoint": "/xyz",
    "backend": [
        // actual backend
        {
            "host": [ "http://127.0.0.1:8080" ],
            "url_pattern": "/xyz"
        },
        // backend expecting shadow requests
        {
            "host": [ "http://127.0.0.1:8088" ],
            "url_pattern": "/xyz",
            "extra_config": {
                "github.com/devopsfaith/krakend/proxy": {
                    "shadow": true
                }
            }
        }
    ]
}
...
```