### PR TITLE
WiP: Support for local CA

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,93 +2,126 @@
 
 
 [[projects]]
+  digest = "1:09d3ceb4456b0b463c5730198a9138e383089b27c0c10b1032789a0618a6dfe6"
   name = "github.com/dimfeld/httptreemux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a454a10de4a11f751681a0914461ab9e98c2a3ff"
   version = "5.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:36fe9527deed01d2a317617e59304eb2c4ce9f8a24115bcc5c2e37b3aee5bae4"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
+  pruneopts = "UT"
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
 
 [[projects]]
+  digest = "1:489e108f21464371ebf9cb5c30b1eceb07c6dd772dff073919267493dd9d04ea"
   name = "github.com/gin-gonic/gin"
   packages = [
     ".",
     "binding",
-    "render"
+    "render",
   ]
+  pruneopts = "UT"
   revision = "d459835d2b077e44f7c9b453505ee29881d5d12d"
   version = "v1.2"
 
 [[projects]]
+  digest = "1:631757aef84dd471e4ba8242ac6affcccfc2c4c6d9c8c45e47b0d8fe8fd82de1"
   name = "github.com/go-chi/chi"
   packages = [
     ".",
-    "middleware"
+    "middleware",
   ]
+  pruneopts = "UT"
   revision = "1a6bb108ccf279c8dac6f9bad857d773b4f9b421"
   version = "v4.0.1"
 
 [[projects]]
+  digest = "1:ffc060c551980d37ee9e428ef528ee2813137249ccebb0bfc412ef83071cac91"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:160eabf7a69910fd74f29c692718bc2437c1c1c7d4c9dea9712357752a70e5df"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:88aa9e326e2bd6045a46e00a922954b3e1a9ac5787109f49ac85366df370e1e5"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:397231009a0a63692093d9dd439f382ce4ac499f26bc5a0978e168c596d2400b"
   name = "github.com/ugorji/go"
   packages = ["codec"]
+  pruneopts = "UT"
   revision = "9831f2c3ac1068a78f50999a30db84270f647af6"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:606d068450c82b9ddaa21de992f73563754077f0f411235cdfe71d0903a268c3"
   name = "github.com/urfave/negroni"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c6198b3fa0b4077e50563294cd42f51180380d31bf9c951023a181ad81e2685b"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "3b87a42e500a6dc65dae1a55d0b641295971163e"
 
 [[projects]]
+  digest = "1:cbc72c4c4886a918d6ab4b95e347ffe259846260f99ebdd8a198c2331cf2b2e9"
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
   version = "v8.18.2"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "455fd8797a376ebebaa365fa68ff28c866e203f78a38a464830874498e674596"
+  input-imports = [
+    "github.com/dimfeld/httptreemux",
+    "github.com/gin-gonic/gin",
+    "github.com/go-chi/chi",
+    "github.com/go-chi/chi/middleware",
+    "github.com/gorilla/mux",
+    "github.com/urfave/negroni",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/config.go
+++ b/config/config.go
@@ -234,6 +234,7 @@ type TLS struct {
 	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
 	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
 	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
+	LocalCA                  string   `mapstructure:"local_ca"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/transport/http/client/executor.go
+++ b/transport/http/client/executor.go
@@ -2,7 +2,16 @@ package client
 
 import (
 	"context"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
 	"net/http"
+	"sync"
+	"time"
+
+	"github.com/devopsfaith/krakend/config"
+	krakendhttp "github.com/devopsfaith/krakend/transport/http"
 )
 
 // HTTPRequestExecutor defines the interface of the request executor for the HTTP transport protocol
@@ -22,3 +31,60 @@ type HTTPClientFactory func(ctx context.Context) *http.Client
 func NewHTTPClient(ctx context.Context) *http.Client { return defaultHTTPClient }
 
 var defaultHTTPClient = &http.Client{}
+
+var once sync.Once
+
+// InitHTTPDefaultTransport inits the transport component of the default HTTP client
+func InitHTTPDefaultTransport(cfg config.ServiceConfig) error {
+	var err error
+	once.Do(func() {
+		var dc *http.Client
+		dc, err = newHTTPClient(cfg)
+		if dc != nil {
+			defaultHTTPClient = dc
+		}
+	})
+	return err
+}
+
+func newHTTPClient(cfg config.ServiceConfig) (*http.Client, error) {
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+	}
+
+	if cfg.TLS == nil || cfg.TLS.IsDisabled {
+		return &http.Client{
+			Transport: transport,
+		}, nil
+	}
+
+	transport.TLSClientConfig = krakendhttp.ParseTLSConfig(cfg.TLS)
+
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	if cfg.TLS.LocalCA != "" {
+		certs, err := ioutil.ReadFile(cfg.TLS.LocalCA)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to append %s to RootCAs: %v", cfg.TLS.LocalCA, err)
+		}
+		rootCAs.AppendCertsFromPEM(certs)
+	}
+
+	transport.TLSClientConfig.RootCAs = rootCAs
+
+	return &http.Client{
+		Transport: transport,
+	}, nil
+}

--- a/transport/http/client/executor_test.go
+++ b/transport/http/client/executor_test.go
@@ -1,3 +1,4 @@
+//go:generate go run $GOROOT/src/crypto/tls/generate_cert.go --rsa-bits 1024 --host 127.0.0.1,::1,localhost --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
 package client
 
 import (
@@ -5,13 +6,21 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/devopsfaith/krakend/config"
 )
 
-func TestDefaultHTTPRequestExecutor(t *testing.T) {
+func init() {
+	rand.Seed(time.Now().Unix())
+}
 
+func TestDefaultHTTPRequestExecutor(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, client")
 	}))
@@ -30,4 +39,121 @@ func TestDefaultHTTPRequestExecutor(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Error("unexpected status code:", resp.StatusCode)
 	}
+}
+
+func TestInitHTTPDefaultTransport(t *testing.T) {
+	testKeysAreAvailable(t)
+
+	cleanUp()
+	defer cleanUp()
+
+	err := InitHTTPDefaultTransport(config.ServiceConfig{TLS: &config.TLS{
+		LocalCA: "cert.pem",
+	}})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	port := newPort()
+	s := http.Server{
+		Addr: fmt.Sprintf(":%d", port),
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Write([]byte("ok"))
+		}),
+	}
+	defer s.Close()
+	go func() {
+		s.ListenAndServeTLS("cert.pem", "key.pem")
+	}()
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d/", port), nil)
+	resp, err := defaultHTTPClient.Do(req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("unexpected status code. have: %d, want: 200", resp.StatusCode)
+	}
+}
+
+func TestInitHTTPDefaultTransport_unknownCA(t *testing.T) {
+	testKeysAreAvailable(t)
+
+	cleanUp()
+	defer cleanUp()
+
+	err := InitHTTPDefaultTransport(config.ServiceConfig{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	port := newPort()
+	s := http.Server{
+		Addr: fmt.Sprintf(":%d", port),
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.Write([]byte("ok"))
+		}),
+	}
+	defer s.Close()
+	go func() {
+		s.ListenAndServeTLS("cert.pem", "key.pem")
+	}()
+
+	req, _ := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d/", port), nil)
+	resp, err := defaultHTTPClient.Do(req)
+	expectedErr := fmt.Sprintf("Get https://localhost:%d/: x509: certificate signed by unknown authority", port)
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if resp != nil {
+		t.Errorf("unexpected response. have: %v", resp)
+	}
+}
+
+func Test_newHTTPClient_unknownCAPath(t *testing.T) {
+	testKeysAreAvailable(t)
+
+	client, err := newHTTPClient(config.ServiceConfig{TLS: &config.TLS{LocalCA: "no_such_file"}})
+	if err == nil || err.Error() != "Failed to append no_such_file to RootCAs: open no_such_file: no such file or directory" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if client != nil {
+		t.Errorf("unexpected client %v", client)
+	}
+}
+
+func testKeysAreAvailable(t *testing.T) {
+	files, err := ioutil.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, k := range []string{"cert.pem", "key.pem"} {
+		var exists bool
+		for _, file := range files {
+			if file.Name() == k {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			t.Errorf("file %s not present", k)
+		}
+	}
+}
+
+func newPort() int {
+	return 16600 + rand.Intn(40000)
+}
+
+func cleanUp() {
+	once = sync.Once{}
+	defaultHTTPClient = &http.Client{}
 }

--- a/transport/http/client/executor_test.go
+++ b/transport/http/client/executor_test.go
@@ -103,6 +103,7 @@ func TestInitHTTPDefaultTransport_unknownCA(t *testing.T) {
 		s.ListenAndServeTLS("cert.pem", "key.pem")
 	}()
 
+	<-time.After(200 * time.Millisecond)
 	req, _ := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d/", port), nil)
 	resp, err := defaultHTTPClient.Do(req)
 	expectedErr := fmt.Sprintf("Get https://localhost:%d/: x509: certificate signed by unknown authority", port)

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"crypto/tls"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+// ParseTLSConfig creates a tls.Config from the TLS section of the service configuration
+func ParseTLSConfig(cfg *config.TLS) *tls.Config {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.IsDisabled {
+		return nil
+	}
+
+	return &tls.Config{
+		MinVersion:               parseTLSVersion(cfg.MinVersion),
+		MaxVersion:               parseTLSVersion(cfg.MaxVersion),
+		CurvePreferences:         parseCurveIDs(cfg),
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		CipherSuites:             parseCipherSuites(cfg),
+	}
+}
+
+func parseTLSVersion(key string) uint16 {
+	if v, ok := TLSVersions[key]; ok {
+		return v
+	}
+	return tls.VersionTLS12
+}
+
+func parseCurveIDs(cfg *config.TLS) []tls.CurveID {
+	l := len(cfg.CurvePreferences)
+	if l == 0 {
+		return DefaultCurves
+	}
+
+	curves := make([]tls.CurveID, len(cfg.CurvePreferences))
+	for i := range curves {
+		curves[i] = tls.CurveID(cfg.CurvePreferences[i])
+	}
+	return curves
+}
+
+func parseCipherSuites(cfg *config.TLS) []uint16 {
+	l := len(cfg.CipherSuites)
+	if l == 0 {
+		return DefaultCipherSuites
+	}
+
+	cs := make([]uint16, l)
+	for i := range cs {
+		cs[i] = uint16(cfg.CipherSuites[i])
+	}
+	return cs
+}
+
+var (
+	// DefaultCurves are the preferred curve ids
+	DefaultCurves = []tls.CurveID{
+		tls.CurveP521,
+		tls.CurveP384,
+		tls.CurveP256,
+	}
+	// DefaultCipherSuites contains the preferred ciphersuites
+	DefaultCipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}
+	// TLSVersions is a map between tls versions and their ids
+	TLSVersions = map[string]uint16{
+		"SSL3.0": tls.VersionSSL30,
+		"TLS10":  tls.VersionTLS10,
+		"TLS11":  tls.VersionTLS11,
+		"TLS12":  tls.VersionTLS12,
+	}
+)

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+
+	"github.com/devopsfaith/krakend/config"
+)
+
+func TestParseTLSConfig_nilConfig(t *testing.T) {
+	if res := ParseTLSConfig(nil); res != nil {
+		t.Errorf("unexpected result. have: %v, want nil", res)
+	}
+}
+
+func TestParseTLSConfig_disabledConfig(t *testing.T) {
+	if res := ParseTLSConfig(&config.TLS{IsDisabled: true}); res != nil {
+		t.Errorf("unexpected result. have: %v, want nil", res)
+	}
+}
+
+func TestParseTLSConfig_emptyConfig(t *testing.T) {
+	res := ParseTLSConfig(&config.TLS{})
+	if res == nil {
+		t.Error("nil result")
+		return
+	}
+
+	if !reflect.DeepEqual(res.CipherSuites, DefaultCipherSuites) {
+		t.Errorf("unexpected cipher suites: %v", res.CipherSuites)
+	}
+
+	if !reflect.DeepEqual(res.CurvePreferences, DefaultCurves) {
+		t.Errorf("unexpected cipher suites: %v", res.CurvePreferences)
+	}
+
+	if res.MinVersion != tls.VersionTLS12 || res.MaxVersion != tls.VersionTLS12 {
+		t.Errorf("max and min version should be %v. min: %v, max: %v", tls.VersionTLS12, res.MinVersion, res.MaxVersion)
+	}
+}
+
+func Test_parseTLSVersion(t *testing.T) {
+	for _, tc := range []struct {
+		in  string
+		out uint16
+	}{
+		{in: "SSL3.0", out: tls.VersionSSL30},
+		{in: "TLS10", out: tls.VersionTLS10},
+		{in: "TLS11", out: tls.VersionTLS11},
+		{in: "TLS12", out: tls.VersionTLS12},
+		{in: "Unknown", out: tls.VersionTLS12},
+	} {
+		if res := parseTLSVersion(tc.in); res != tc.out {
+			t.Errorf("input %s generated output %d. expected: %d", tc.in, res, tc.out)
+		}
+	}
+}
+
+func Test_parseCurveIDs(t *testing.T) {
+	original := []uint16{1, 2, 3}
+	cs := parseCurveIDs(&config.TLS{CurvePreferences: original})
+	for k, v := range cs {
+		if original[k] != uint16(v) {
+			t.Errorf("unexpected curves %v. expected: %v", cs, original)
+		}
+	}
+}
+
+func Test_parseCipherSuites(t *testing.T) {
+	original := []uint16{1, 2, 3}
+	cs := parseCipherSuites(&config.TLS{CipherSuites: original})
+	for k, v := range cs {
+		if original[k] != uint16(v) {
+			t.Errorf("unexpected ciphersuites %v. expected: %v", cs, original)
+		}
+	}
+}

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -111,7 +111,7 @@ func NewServer(cfg config.ServiceConfig, handler http.Handler) *http.Server {
 		WriteTimeout:      cfg.WriteTimeout,
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		IdleTimeout:       cfg.IdleTimeout,
-		TLSConfig:         krakendhttp.ParseTLSConfig(cfg.TLS),
+		TLSConfig:         ParseTLSConfig(cfg.TLS),
 	}
 }
 

--- a/transport/http/server/server.go
+++ b/transport/http/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/core"
+	krakendhttp "github.com/devopsfaith/krakend/transport/http"
 )
 
 // ToHTTPError translates an error into a HTTP status code
@@ -110,80 +111,13 @@ func NewServer(cfg config.ServiceConfig, handler http.Handler) *http.Server {
 		WriteTimeout:      cfg.WriteTimeout,
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		IdleTimeout:       cfg.IdleTimeout,
-		TLSConfig:         ParseTLSConfig(cfg.TLS),
+		TLSConfig:         krakendhttp.ParseTLSConfig(cfg.TLS),
 	}
 }
 
 // ParseTLSConfig creates a tls.Config from the TLS section of the service configuration
 func ParseTLSConfig(cfg *config.TLS) *tls.Config {
-	if cfg == nil {
-		return nil
-	}
-	if cfg.IsDisabled {
-		return nil
-	}
-
-	return &tls.Config{
-		MinVersion:               parseTLSVersion(cfg.MinVersion),
-		MaxVersion:               parseTLSVersion(cfg.MaxVersion),
-		CurvePreferences:         parseCurveIDs(cfg),
-		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
-		CipherSuites:             parseCipherSuites(cfg),
-	}
+	return krakendhttp.ParseTLSConfig(cfg)
 }
 
-func parseTLSVersion(key string) uint16 {
-	if v, ok := versions[key]; ok {
-		return v
-	}
-	return tls.VersionTLS12
-}
-
-func parseCurveIDs(cfg *config.TLS) []tls.CurveID {
-	l := len(cfg.CurvePreferences)
-	if l == 0 {
-		return defaultCurves
-	}
-
-	curves := make([]tls.CurveID, len(cfg.CurvePreferences))
-	for i := range curves {
-		curves[i] = tls.CurveID(cfg.CurvePreferences[i])
-	}
-	return curves
-}
-
-func parseCipherSuites(cfg *config.TLS) []uint16 {
-	l := len(cfg.CipherSuites)
-	if l == 0 {
-		return defaultCipherSuites
-	}
-
-	cs := make([]uint16, l)
-	for i := range cs {
-		cs[i] = uint16(cfg.CipherSuites[i])
-	}
-	return cs
-}
-
-var (
-	onceTransportConfig sync.Once
-	defaultCurves       = []tls.CurveID{
-		tls.CurveP521,
-		tls.CurveP384,
-		tls.CurveP256,
-	}
-	defaultCipherSuites = []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-	}
-	versions = map[string]uint16{
-		"SSL3.0": tls.VersionSSL30,
-		"TLS10":  tls.VersionTLS10,
-		"TLS11":  tls.VersionTLS11,
-		"TLS12":  tls.VersionTLS12,
-	}
-)
+var onceTransportConfig sync.Once

--- a/transport/http/server/server_test.go
+++ b/transport/http/server/server_test.go
@@ -191,43 +191,6 @@ func TestRunServer_errBadKeys(t *testing.T) {
 	}
 }
 
-func Test_parseTLSVersion(t *testing.T) {
-	for _, tc := range []struct {
-		in  string
-		out uint16
-	}{
-		{in: "SSL3.0", out: tls.VersionSSL30},
-		{in: "TLS10", out: tls.VersionTLS10},
-		{in: "TLS11", out: tls.VersionTLS11},
-		{in: "TLS12", out: tls.VersionTLS12},
-		{in: "Unknown", out: tls.VersionTLS12},
-	} {
-		if res := parseTLSVersion(tc.in); res != tc.out {
-			t.Errorf("input %s generated output %d. expected: %d", tc.in, res, tc.out)
-		}
-	}
-}
-
-func Test_parseCurveIDs(t *testing.T) {
-	original := []uint16{1, 2, 3}
-	cs := parseCurveIDs(&config.TLS{CurvePreferences: original})
-	for k, v := range cs {
-		if original[k] != uint16(v) {
-			t.Errorf("unexpected curves %v. expected: %v", cs, original)
-		}
-	}
-}
-
-func Test_parseCipherSuites(t *testing.T) {
-	original := []uint16{1, 2, 3}
-	cs := parseCipherSuites(&config.TLS{CipherSuites: original})
-	for k, v := range cs {
-		if original[k] != uint16(v) {
-			t.Errorf("unexpected ciphersuites %v. expected: %v", cs, original)
-		}
-	}
-}
-
 func dummyHandler(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "Hello, %q", html.EscapeString(req.URL.Path))
 }


### PR DESCRIPTION
https internal clients do not support extending the system CA. This PR extends the TLS support for the `http` transport package by moving it from the `server` sub-package to `http`.