### PR TITLE
use strings.Builder for url building

### DIFF
--- a/proxy/balancing.go
+++ b/proxy/balancing.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/devopsfaith/krakend/config"
@@ -45,10 +46,10 @@ func newLoadBalancedMiddleware(lb sd.Balancer) Middleware {
 			}
 			r := request.Clone()
 
-			rawURL := []byte{}
-			rawURL = append(rawURL, host...)
-			rawURL = append(rawURL, r.Path...)
-			r.URL, err = url.Parse(string(rawURL))
+			var b strings.Builder
+			b.WriteString(host)
+			b.WriteString(r.Path)
+			r.URL, err = url.Parse(b.String())
 			if err != nil {
 				return nil, err
 			}

--- a/proxy/balancing_benchmark_test.go
+++ b/proxy/balancing_benchmark_test.go
@@ -6,12 +6,33 @@ import (
 )
 
 func BenchmarkNewLoadBalancedMiddleware(b *testing.B) {
-	proxy := newLoadBalancedMiddleware(dummyBalancer("supu"))(dummyProxy(&Response{}))
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		proxy(context.Background(), &Request{
-			Path: "/tupu",
+	for _, tc := range []struct {
+		name string
+		host string
+		path string
+	}{
+		{name: "3", host: "abc", path: "abc"},
+		{name: "5", host: "abcde", path: "abcde"},
+		{name: "9", host: "abcdefghi", path: "abcdefghi"},
+		{name: "13", host: "abcdefghijklm", path: "abcdefghijklm"},
+		{name: "17", host: "abcdefghijklmopqr", path: "abcdefghijklmopqr"},
+		{name: "21", host: "abcdefghijklmopqrstuv", path: "abcdefghijklmopqrstuv"},
+		{name: "25", host: "abcdefghijklmopqrstuvwxyz", path: "abcdefghijklmopqrstuvwxyz"},
+		{
+			name: "50",
+			host: "abcdefghijklmopqrstuvwxyzabcdefghijklmopqrstuvwxyz",
+			path: "abcdefghijklmopqrstuvwxyzabcdefghijklmopqrstuvwxyz",
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			proxy := newLoadBalancedMiddleware(dummyBalancer(tc.host))(dummyProxy(&Response{}))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				proxy(context.Background(), &Request{
+					Path: tc.path,
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
this PR uses strings.Builder instead of custom building strategies at the balancer middleware.

since the release of the 1.10 version of the go language introduced the `strings.Builder` struct, its performance has been improved and tests say it's time to adopt this implementation.

The changes introduced in this PR reduce the number and the size of the required memory allocations requested by this mw, relaxing the memory gc requirements

<img width="723" alt="Captura de pantalla 2019-03-27 a las 2 14 17" src="https://user-images.githubusercontent.com/1307694/55043376-4eae1b80-5036-11e9-8292-b7afba3a1350.png">
