### PR TITLE
sequential merger: use a type switch instead of always going with fmt

### DIFF
--- a/proxy/merging.go
+++ b/proxy/merging.go
@@ -103,7 +103,18 @@ func sequentialMerge(patterns []string, timeout time.Duration, rc ResponseCombin
 						if !ok {
 							continue
 						}
-						request.Params[key] = fmt.Sprintf("%v", v)
+						switch clean := v.(type) {
+						case string:
+							request.Params[key] = clean
+						case int:
+							request.Params[key] = strconv.Itoa(clean)
+						case float64:
+							request.Params[key] = strconv.FormatFloat(clean, 'E', -1, 32)
+						case bool:
+							request.Params[key] = strconv.FormatBool(clean)
+						default:
+							request.Params[key] = fmt.Sprintf("%v", v)
+						}
 					}
 				}
 			}

--- a/proxy/merging_benchmark_test.go
+++ b/proxy/merging_benchmark_test.go
@@ -17,16 +17,16 @@ func BenchmarkNewMergeDataMiddleware(b *testing.B) {
 	}
 
 	proxies := []Proxy{
-		dummyProxy(&Response{Data: map[string]interface{}{"supu": 42}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"tupu": true}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"foo": "bar"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"foobar": false}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"qux": "false"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"data": "the quick brow fox"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"status": "ok"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"aaaa": "aaaaaaaaaaaa"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"bbbbb": 3.14}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"cccc": map[string]interface{}{"a": 42}}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
 	}
 
 	for _, totalParts := range []int{2, 3, 4, 5, 6, 7, 8, 9, 10} {
@@ -39,30 +39,41 @@ func BenchmarkNewMergeDataMiddleware(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				proxy(context.Background(), &Request{})
+				proxy(context.Background(), &Request{Params: map[string]string{}})
 			}
 		})
 	}
 }
 
 func BenchmarkNewMergeDataMiddleware_sequential(b *testing.B) {
-	backend := config.Backend{}
 	backends := make([]*config.Backend, 10)
+	pattern := "/some"
+	keys := []string{}
 	for i := range backends {
-		backends[i] = &backend
+		b := &config.Backend{
+			URLKeys:    make([]string, 4*i),
+			URLPattern: pattern,
+		}
+		copy(b.URLKeys, keys)
+		backends[i] = b
+		for _, t := range []string{"int", "float", "bool", "string"} {
+			next := fmt.Sprintf("Resp%d_%s", i, t)
+			pattern += "/{{." + next + "}}"
+			keys = append(keys, next)
+		}
 	}
 
 	proxies := []Proxy{
-		dummyProxy(&Response{Data: map[string]interface{}{"supu": 42}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"tupu": true}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"foo": "bar"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"foobar": false}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"qux": "false"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"data": "the quick brow fox"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"status": "ok"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"aaaa": "aaaaaaaaaaaa"}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"bbbbb": 3.14}, IsComplete: true}),
-		dummyProxy(&Response{Data: map[string]interface{}{"cccc": map[string]interface{}{"a": 42}}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
+		dummyProxy(&Response{Data: map[string]interface{}{"int": 1, "float": 3.14, "bool": true, "string": "wwwww"}, IsComplete: true}),
 	}
 
 	for _, totalParts := range []int{2, 3, 4, 5, 6, 7, 8, 9, 10} {
@@ -80,7 +91,7 @@ func BenchmarkNewMergeDataMiddleware_sequential(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				proxy(context.Background(), &Request{})
+				proxy(context.Background(), &Request{Params: map[string]string{}})
 			}
 		})
 	}


### PR DESCRIPTION
```
$ go test -bench BenchmarkNewMergeDataMiddleware_sequential -benchmem
```

  | bench_fmt.txt | bench_type.txt | delta | conf
-- | -- | -- | -- | --
with_2_parts-8 | 6.07µs ± 1% | 5.80µs ± 3% | −4.45% | (p=0.002 n=6+6)
with_3_parts-8 | 13.7µs ± 1% | 13.2µs ± 4% | −3.89% | (p=0.026 n=6+6)
with_4_parts-8 | 25.6µs ± 1% | 24.0µs ± 1% | −5.94% | (p=0.004 n=6+5)
with_5_parts-8 | 40.9µs ± 0% | 38.9µs ± 2% | −4.98% | (p=0.004 n=5+6)
with_6_parts-8 | 58.8µs ± 0% | 55.6µs ± 3% | −5.37% | (p=0.004 n=5+6)
with_7_parts-8 | 80.2µs ± 0% | 77.0µs ± 4% | ~ | (p=0.082 n=5+6)
with_8_parts-8 | 107µs ± 0% | 102µs ± 3% | −4.97% | (p=0.002 n=6+6)
with_9_parts-8 | 135µs ± 0% | 129µs ± 4% | −4.72% | (p=0.004 n=5+6)
with_10_parts-8 | 166µs ± 0% | 157µs ± 5% | −5.63% | (p=0.002 n=6+6)
[Geo mean] | 46.4µs | 44.1µs | −4.89%

