### PR TITLE
propagate the content length if present

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/devopsfaith/krakend/config"
@@ -54,6 +55,13 @@ func NewHTTPProxyDetailed(remote *config.Backend, re client.HTTPRequestExecutor,
 			tmp := make([]string, len(vs))
 			copy(tmp, vs)
 			requestToBakend.Header[k] = tmp
+		}
+		if request.Body != nil {
+			if v, ok := request.Headers["Content-Length"]; ok && len(v) == 1 && v[0] != "chunked" {
+				if size, err := strconv.Atoi(v[0]); err == nil {
+					requestToBakend.ContentLength = int64(size)
+				}
+			}
 		}
 
 		resp, err := re(ctx, requestToBakend)

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -21,6 +21,12 @@ import (
 func TestNewHTTPProxy_ok(t *testing.T) {
 	expectedMethod := "GET"
 	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ContentLength != 11 {
+			t.Errorf("unexpected request size. Want: 11. Have: %d", r.ContentLength)
+		}
+		if h := r.Header.Get("Content-Length"); h != "11" {
+			t.Errorf("unexpected content-length header. Want: 11. Have: %s", h)
+		}
 		if r.Method != expectedMethod {
 			t.Errorf("Wrong request method. Want: %s. Have: %s", expectedMethod, r.Method)
 		}
@@ -43,10 +49,11 @@ func TestNewHTTPProxy_ok(t *testing.T) {
 		Method: expectedMethod,
 		Path:   "/",
 		URL:    rpURL,
-		Body:   newDummyReadCloser(""),
+		Body:   newDummyReadCloser(`{"abc": 42}`),
 		Headers: map[string][]string{
-			"X-First":  {"first"},
-			"X-Second": {"second"},
+			"X-First":        {"first"},
+			"X-Second":       {"second"},
+			"Content-Length": {"11"},
 		},
 	}
 	mustEnd := time.After(time.Duration(150) * time.Millisecond)


### PR DESCRIPTION
as requested at #129 and #234 this PR propagates the `Content-Length` header to the backend request if it is present in the proxy request (it must be forwarded there explicitly using the `headers_to_pass`)