### PR TITLE
Push KrakenD User-Agent only if not overriding forwarded Header

### DIFF
--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -109,8 +109,15 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 				headers[k] = h
 			}
 		}
+
 		headers["X-Forwarded-For"] = []string{c.ClientIP()}
-		headers["User-Agent"] = router.UserAgentHeaderValue
+		// if User-Agent is not forwarded using headersToSend, we set
+		// the KrakenD router User Agent value
+		if _, ok := headers["User-Agent"]; !ok {
+			headers["User-Agent"] = router.UserAgentHeaderValue
+		} else {
+			headers["X-Forwarded-Via"] = router.UserAgentHeaderValue
+		}
 
 		query := make(map[string][]string, len(queryString))
 		queryValues := c.Request.URL.Query()

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -134,7 +134,13 @@ func NewRequestBuilder(paramExtractor ParamExtractor) RequestBuilder {
 		} else {
 			headers["X-Forwarded-For"] = []string{r.RemoteAddr}
 		}
-		headers["User-Agent"] = router.UserAgentHeaderValue
+		// if User-Agent is not forwarded using headersToSend, we set
+		// the KrakenD router User Agent value
+		if _, ok := headers["User-Agent"]; !ok {
+			headers["User-Agent"] = router.UserAgentHeaderValue
+		} else {
+			headers["X-Forwarded-Via"] = router.UserAgentHeaderValue
+		}
 
 		query := make(map[string][]string, len(queryString))
 		queryValues := r.URL.Query()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -246,9 +246,10 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 			headers: map[string]string{
 				"x-Test-1": "some",
 				"X-TEST-2": "none",
+				"User-Agent": "KrakenD Test",
 			},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Test-1":["some"],"X-Test-2":["none"]},"path":"/all-params","query":{}}`,
+			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Test"],"X-Forwarded-Via":["KrakenD Version undefined"],"X-Test-1":["some"],"X-Test-2":["none"]},"path":"/all-params","query":{}}`,
 		},
 		{
 			name:       "sequential ok",


### PR DESCRIPTION
This PR prevent KrakenD from overriding the User-Agent, if the user wants to forward that header (if he specifies `User-Agent` or `*` and the header is present)
