### PR TITLE
TLS tags

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -153,8 +153,8 @@ type parseableServiceConfig struct {
 	DialerFallbackDelay   string                     `json:"dialer_fallback_delay"`
 	DialerKeepAlive       string                     `json:"dialer_keep_alive"`
 	Debug                 bool
-	Plugin                *Plugin `json:"plugin,omitempty"`
-	TLS                   *TLS    `json:"tls,omitempty"`
+	Plugin                *Plugin       `json:"plugin,omitempty"`
+	TLS                   *parseableTLS `json:"tls,omitempty"`
 }
 
 func (p *parseableServiceConfig) normalize() ServiceConfig {
@@ -182,7 +182,18 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 		DialerKeepAlive:       parseDuration(p.DialerKeepAlive),
 		OutputEncoding:        p.OutputEncoding,
 		Plugin:                p.Plugin,
-		TLS:                   p.TLS,
+	}
+	if p.TLS != nil {
+		cfg.TLS = &TLS{
+			IsDisabled:               p.TLS.IsDisabled,
+			PublicKey:                p.TLS.PublicKey,
+			PrivateKey:               p.TLS.PrivateKey,
+			MinVersion:               p.TLS.MinVersion,
+			MaxVersion:               p.TLS.MaxVersion,
+			CurvePreferences:         p.TLS.CurvePreferences,
+			PreferServerCipherSuites: p.TLS.PreferServerCipherSuites,
+			CipherSuites:             p.TLS.CipherSuites,
+		}
 	}
 	if p.ExtraConfig != nil {
 		cfg.ExtraConfig = *p.ExtraConfig
@@ -193,6 +204,17 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 	}
 	cfg.Endpoints = endpoints
 	return cfg
+}
+
+type parseableTLS struct {
+	IsDisabled               bool     `json:"disabled"`
+	PublicKey                string   `json:"public_key"`
+	PrivateKey               string   `json:"private_key"`
+	MinVersion               string   `json:"min_version"`
+	MaxVersion               string   `json:"max_version"`
+	CurvePreferences         []uint16 `json:"curve_preferences"`
+	PreferServerCipherSuites bool     `json:"prefer_server_cipher_suites"`
+	CipherSuites             []uint16 `json:"cipher_suites"`
 }
 
 type parseableEndpointConfig struct {

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -14,6 +14,10 @@ func TestNewParser_ok(t *testing.T) {
     "port": 8080,
     "cache_ttl": "3600s",
     "timeout": "3s",
+    "tls": {
+		"public_key":  "cert.pem",
+		"private_key": "key.pem"
+	},
     "endpoints": [
         {
             "endpoint": "/github",
@@ -85,6 +89,11 @@ func TestNewParser_ok(t *testing.T) {
 	}
 	testExtraConfig(serviceConfig.ExtraConfig, t)
 
+	if endpoints := len(serviceConfig.Endpoints); endpoints != 3 {
+		t.Errorf("Unexpected number of endpoints: %d", endpoints)
+		return
+	}
+
 	endpoint := serviceConfig.Endpoints[0]
 	endpointExtraConfiguration := endpoint.ExtraConfig
 
@@ -92,6 +101,17 @@ func TestNewParser_ok(t *testing.T) {
 		testExtraConfig(endpointExtraConfiguration, t)
 	} else {
 		t.Error("Extra config is not present in EndpointConfig")
+	}
+
+	if serviceConfig.TLS == nil {
+		t.Error("TLS config not present")
+	} else {
+		if serviceConfig.TLS.PublicKey != "cert.pem" {
+			t.Error("Unexpected TLS Public key")
+		}
+		if serviceConfig.TLS.PrivateKey != "key.pem" {
+			t.Error("Unexpected TLS Private key")
+		}
 	}
 
 	backend := endpoint.Backend[0]
@@ -199,11 +219,11 @@ func testExtraConfig(extraConfig map[string]interface{}, t *testing.T) {
 	if userVar != "test" {
 		t.Error("User in extra config is not test")
 	}
-	parents := extraConfig["parents"].([]interface{})
-	if parents[0] != "gomez" {
+	parents, ok := extraConfig["parents"].([]interface{})
+	if !ok || parents[0] != "gomez" {
 		t.Error("Parent 0 of user us not gomez")
 	}
-	if parents[1] != "morticia" {
+	if !ok || parents[1] != "morticia" {
 		t.Error("Parent 1 of user us not morticia")
 	}
 }


### PR DESCRIPTION
tls options tagged so the default config parser can parse regular config files.

Fixes #291 