### PR TITLE
avoid overflow

### DIFF
--- a/sd/loadbalancing.go
+++ b/sd/loadbalancing.go
@@ -2,6 +2,7 @@ package sd
 
 import (
 	"errors"
+	"math"
 	"runtime"
 	"sync/atomic"
 

--- a/sd/loadbalancing.go
+++ b/sd/loadbalancing.go
@@ -49,6 +49,8 @@ func (r *roundRobinLB) Host() (string, error) {
 		return "", err
 	}
 	offset := (atomic.AddUint64(&r.counter, 1) - 1) % uint64(len(hosts))
+	//avoid overflow
+	offset = math.Abs(offset)
 	return hosts[offset], nil
 }
 


### PR DESCRIPTION
atomic.AddUint64 will lead to overflow