### PR TITLE
clone the request body

### DIFF
--- a/proxy/request.go
+++ b/proxy/request.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"net/url"
 )
 
@@ -57,6 +58,16 @@ func CloneRequest(r *Request) *Request {
 	clone := r.Clone()
 	clone.Headers = CloneRequestHeaders(r.Headers)
 	clone.Params = CloneRequestParams(r.Params)
+	if r.Body == nil {
+		return &clone
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r.Body)
+	r.Body.Close()
+
+	r.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+	clone.Body = ioutil.NopCloser(buf)
+
 	return &clone
 }
 

--- a/proxy/request_test.go
+++ b/proxy/request_test.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "testing"
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+)
 
 func TestRequestGeneratePath(t *testing.T) {
 	r := Request{
@@ -81,8 +85,9 @@ func TestRequest_Clone(t *testing.T) {
 }
 
 func TestCloneRequest(t *testing.T) {
+	body := `{"a":1,"b":2}`
 	r := Request{
-		Method: "GET",
+		Method: "POST",
 		Params: map[string]string{
 			"Supu": "42",
 			"Tupu": "false",
@@ -91,6 +96,7 @@ func TestCloneRequest(t *testing.T) {
 		Headers: map[string][]string{
 			"Content-Type": {"application/json"},
 		},
+		Body: ioutil.NopCloser(strings.NewReader(body)),
 	}
 	clone := CloneRequest(&r)
 
@@ -129,5 +135,12 @@ func TestCloneRequest(t *testing.T) {
 
 	if _, ok := clone.Params["Supu"]; !ok {
 		t.Error("the cloned instance shares its params with the original one")
+	}
+
+	rb, _ := ioutil.ReadAll(r.Body)
+	cb, _ := ioutil.ReadAll(clone.Body)
+
+	if string(cb) != string(rb) || body != string(rb) {
+		t.Errorf("unexpected bodies. original: %s, returned: %s", string(rb), string(cb))
 	}
 }


### PR DESCRIPTION
clone also the request body in the CloneRequest method, so shadow backends get the same body sent to regular backends