### PR TITLE
safe json decoder added

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -29,7 +29,7 @@ func TestRegister(t *testing.T) {
 
 	original := GetRegister()
 
-	if len(original.data.Clone()) != 3 {
+	if len(original.data.Clone()) != 4 {
 		t.Error("Unexpected number of registered factories:", len(original.data.Clone()))
 	}
 
@@ -45,7 +45,7 @@ func TestGet(t *testing.T) {
 	decoders = initDecoderRegister()
 	defer func() { decoders = initDecoderRegister() }()
 
-	if len(decoders.data.Clone()) != 3 {
+	if len(decoders.data.Clone()) != 4 {
 		t.Error("Unexpected number of registered factories:", len(decoders.data.Clone()))
 	}
 

--- a/encoding/json.go
+++ b/encoding/json.go
@@ -34,3 +34,30 @@ func JSONCollectionDecoder(r io.Reader, v *map[string]interface{}) error {
 	*(v) = map[string]interface{}{"collection": collection}
 	return nil
 }
+
+// SAFE_JSON is the key for the json encoding
+const SAFE_JSON = "safejson"
+
+// NewJSONDecoder return the right JSON decoder
+func NewSafeJSONDecoder(isCollection bool) func(io.Reader, *map[string]interface{}) error {
+	return SafeJSONDecoder
+}
+
+// JSONDecoder implements the Decoder interface
+func SafeJSONDecoder(r io.Reader, v *map[string]interface{}) error {
+	d := json.NewDecoder(r)
+	d.UseNumber()
+	var t interface{}
+	if err := d.Decode(&t); err != nil {
+		return err
+	}
+	switch tt := t.(type) {
+	case map[string]interface{}:
+		*v = tt
+	case []interface{}:
+		*v = map[string]interface{}{"collection": tt}
+	default:
+		*v = map[string]interface{}{"result": tt}
+	}
+	return nil
+}

--- a/encoding/json_benchmark_test.go
+++ b/encoding/json_benchmark_test.go
@@ -1,0 +1,58 @@
+package encoding
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func BenchmarkDecoder(b *testing.B) {
+	for _, dec := range []decoderTestCase{
+		{
+			name:    "json-collection",
+			decoder: NewJSONDecoder(true),
+		},
+		{
+			name:    "json-map",
+			decoder: NewJSONDecoder(false),
+		},
+		{
+			name:    "safe-json-collection",
+			decoder: NewSafeJSONDecoder(true),
+		},
+		{
+			name:    "safe-json-map",
+			decoder: NewSafeJSONDecoder(true),
+		},
+	} {
+		for _, tc := range []struct {
+			name  string
+			input string
+		}{
+			{
+				name:  "collection",
+				input: `["a","b","c"]`,
+			},
+			{
+				name:  "map",
+				input: `{"foo": "bar", "supu": false, "tupu": 4.20}`,
+			},
+		} {
+			b.Run(dec.name+"/"+tc.name, func(b *testing.B) {
+				benchmarkDecoder(b, tc.input, dec.decoder)
+			})
+		}
+	}
+}
+
+func benchmarkDecoder(b *testing.B, input string, dec func(io.Reader, *map[string]interface{}) error) {
+	var result map[string]interface{}
+	for i := 0; i < b.N; i++ {
+		_ = dec(strings.NewReader(`["foo", "bar", "supu"]`), &result)
+	}
+}
+
+type decoderTestCase struct {
+	name    string
+	decoder func(io.Reader, *map[string]interface{}) error
+}

--- a/encoding/json_test.go
+++ b/encoding/json_test.go
@@ -61,3 +61,62 @@ func TestNewJSONDecoder_ko(t *testing.T) {
 		t.Error("Expecting error!")
 	}
 }
+
+func TestNewSafeJSONDecoder_map(t *testing.T) {
+	decoder := NewSafeJSONDecoder(false)
+	original := strings.NewReader(`{"foo": "bar", "supu": false, "tupu": 4.20}`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 3 {
+		t.Error("Unexpected result:", result)
+	}
+	if v, ok := result["foo"]; !ok || v.(string) != "bar" {
+		t.Error("wrong result:", result)
+	}
+	if v, ok := result["supu"]; !ok || v.(bool) {
+		t.Error("wrong result:", result)
+	}
+	if v, ok := result["tupu"]; !ok || v.(json.Number).String() != "4.20" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewSafeJSONDecoder_collection(t *testing.T) {
+	decoder := NewSafeJSONDecoder(true)
+	original := strings.NewReader(`["foo", "bar", "supu"]`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if len(result) != 1 {
+		t.Error("Unexpected result:", result)
+	}
+	v, ok := result["collection"]
+	if !ok {
+		t.Error("wrong result:", result)
+	}
+	embedded := v.([]interface{})
+	if embedded[0].(string) != "foo" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[1].(string) != "bar" {
+		t.Error("wrong result:", result)
+	}
+	if embedded[2].(string) != "supu" {
+		t.Error("wrong result:", result)
+	}
+}
+
+func TestNewSafeJSONDecoder_other(t *testing.T) {
+	decoder := NewSafeJSONDecoder(true)
+	original := strings.NewReader(`3`)
+	var result map[string]interface{}
+	if err := decoder(original, &result); err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+	if v, ok := result["result"]; !ok || v.(json.Number).String() != "3" {
+		t.Error("wrong result:", result)
+	}
+}

--- a/encoding/register.go
+++ b/encoding/register.go
@@ -37,9 +37,10 @@ func (r *DecoderRegister) Get(name string) func(bool) func(io.Reader, *map[strin
 var (
 	decoders        = initDecoderRegister()
 	defaultDecoders = map[string]func(bool) func(io.Reader, *map[string]interface{}) error{
-		JSON:   NewJSONDecoder,
-		STRING: NewStringDecoder,
-		NOOP:   noOpDecoderFactory,
+		JSON:      NewJSONDecoder,
+		SAFE_JSON: NewSafeJSONDecoder,
+		STRING:    NewStringDecoder,
+		NOOP:      noOpDecoderFactory,
 	}
 )
 


### PR DESCRIPTION
```
$ go test -bench . -benchmem -benchtime 10s
goos: darwin
goarch: amd64
pkg: github.com/devopsfaith/krakend/encoding
BenchmarkDecoder/json-collection/collection-8         	 7517224	      1605 ns/op	    1472 B/op	      17 allocs/op
BenchmarkDecoder/json-collection/map-8                	 7459869	      1606 ns/op	    1472 B/op	      17 allocs/op
BenchmarkDecoder/json-map/collection-8                	17147770	       710 ns/op	     992 B/op	       6 allocs/op
BenchmarkDecoder/json-map/map-8                       	16881831	       704 ns/op	     992 B/op	       6 allocs/op
BenchmarkDecoder/safe-json-collection/collection-8    	 8487573	      1407 ns/op	    1504 B/op	      19 allocs/op
BenchmarkDecoder/safe-json-collection/map-8           	 8509557	      1406 ns/op	    1504 B/op	      19 allocs/op
BenchmarkDecoder/safe-json-map/collection-8           	 8538740	      1407 ns/op	    1504 B/op	      19 allocs/op
BenchmarkDecoder/safe-json-map/map-8                  	 8451696	      1406 ns/op	    1504 B/op	      19 allocs/op
PASS
ok  	github.com/devopsfaith/krakend/encoding	106.298s
```

this json decoder accepts any kind of json input (in opposition of the regular one). the downside of such flexibility is a decrement in throughput and an increment in memory consumed and allocations