### PR TITLE
Allow "sequential proxy" work with POST, PUT and DELETE methods

### DIFF
--- a/router/chi/router.go
+++ b/router/chi/router.go
@@ -124,23 +124,9 @@ func (r chiRouter) registerKrakendEndpoint(method string, endpoint *config.Endpo
 	method = strings.ToTitle(method)
 	path := endpoint.Endpoint
 	if method != http.MethodGet && totBackends > 1 {
-		if endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"] == nil {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+		if !router.IsValidSequentialEndpoint(endpoint) {
+			r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
 			return
-		}
-
-		proxyCfg := endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"].(map[string]interface{})
-		if proxyCfg["sequential"] == false {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
-			return
-		}
-
-		for i, backend := range endpoint.Backend {
-			r.cfg.Logger.Info(i, " -> ", backend.Method)
-			if backend.Method != http.MethodGet && (i+1) != totBackends {
-				r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
-				return
-			}
 		}
 	}
 

--- a/router/chi/router.go
+++ b/router/chi/router.go
@@ -116,15 +116,32 @@ func (r chiRouter) registerKrakendEndpoints(endpoints []*config.EndpointConfig) 
 			continue
 		}
 
-		r.registerKrakendEndpoint(c.Method, c.Endpoint, r.cfg.HandlerFactory(c, proxyStack), len(c.Backend))
+		r.registerKrakendEndpoint(c.Method, c, r.cfg.HandlerFactory(c, proxyStack), len(c.Backend))
 	}
 }
 
-func (r chiRouter) registerKrakendEndpoint(method, path string, handler http.HandlerFunc, totBackends int) {
+func (r chiRouter) registerKrakendEndpoint(method string, endpoint *config.EndpointConfig, handler http.HandlerFunc, totBackends int) {
 	method = strings.ToTitle(method)
+	path := endpoint.Endpoint
 	if method != http.MethodGet && totBackends > 1 {
-		r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
-		return
+		if endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"] == nil {
+			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+			return
+		}
+
+		proxyCfg := endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"].(map[string]interface{})
+		if proxyCfg["sequential"] == false {
+			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+			return
+		}
+
+		for i, backend := range endpoint.Backend {
+			r.cfg.Logger.Info(i, " -> ", backend.Method)
+			if backend.Method != http.MethodGet && (i+1) != totBackends {
+				r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
+				return
+			}
+		}
 	}
 
 	switch method {

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -108,16 +108,34 @@ func (r ginRouter) registerKrakendEndpoints(endpoints []*config.EndpointConfig) 
 			continue
 		}
 
-		r.registerKrakendEndpoint(c.Method, c.Endpoint, r.cfg.HandlerFactory(c, proxyStack), len(c.Backend))
+		r.registerKrakendEndpoint(c.Method, c, r.cfg.HandlerFactory(c, proxyStack), len(c.Backend))
 	}
 }
 
-func (r ginRouter) registerKrakendEndpoint(method, path string, handler gin.HandlerFunc, totBackends int) {
+func (r ginRouter) registerKrakendEndpoint(method string, endpoint *config.EndpointConfig, handler gin.HandlerFunc, totBackends int) {
 	method = strings.ToTitle(method)
+	path := endpoint.Endpoint
 	if method != http.MethodGet && totBackends > 1 {
-		r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
-		return
+		if endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"] == nil {
+			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+			return
+		}
+
+		proxyCfg := endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"].(map[string]interface{})
+		if proxyCfg["sequential"] == false {
+			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+			return
+		}
+
+		for i, backend := range endpoint.Backend {
+			r.cfg.Logger.Info(i, " -> ", backend.Method)
+			if backend.Method != http.MethodGet && (i+1) != totBackends {
+				r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
+				return
+			}
+		}
 	}
+
 	switch method {
 	case http.MethodGet:
 		r.cfg.Engine.GET(path, handler)

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -116,23 +116,9 @@ func (r ginRouter) registerKrakendEndpoint(method string, endpoint *config.Endpo
 	method = strings.ToTitle(method)
 	path := endpoint.Endpoint
 	if method != http.MethodGet && totBackends > 1 {
-		if endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"] == nil {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+		if !router.IsValidSequentialEndpoint(endpoint) {
+			r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
 			return
-		}
-
-		proxyCfg := endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"].(map[string]interface{})
-		if proxyCfg["sequential"] == false {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
-			return
-		}
-
-		for i, backend := range endpoint.Backend {
-			r.cfg.Logger.Info(i, " -> ", backend.Method)
-			if backend.Method != http.MethodGet && (i+1) != totBackends {
-				r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
-				return
-			}
 		}
 	}
 

--- a/router/helper.go
+++ b/router/helper.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/proxy"
+	"net/http"
+)
+
+func IsValidSequentialEndpoint(endpoint *config.EndpointConfig) bool {
+	if endpoint.ExtraConfig[proxy.Namespace] == nil {
+		return false
+	}
+
+	proxyCfg := endpoint.ExtraConfig[proxy.Namespace].(map[string]interface{})
+	if proxyCfg["sequential"] == false {
+		return false
+	}
+
+	for i, backend := range endpoint.Backend {
+		if backend.Method != http.MethodGet && (i+1) != len(endpoint.Backend) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/router/helper_test.go
+++ b/router/helper_test.go
@@ -1,0 +1,137 @@
+package router
+
+import (
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/proxy"
+	"testing"
+)
+
+func TestIsValidSequentialEndpoint_ok(t *testing.T) {
+
+	endpoint := &config.EndpointConfig{
+		Endpoint: "/correct",
+		Method:   "PUT",
+		Backend: []*config.Backend{
+			{
+				Method: "GET",
+			},
+			{
+				Method: "PUT",
+			},
+		},
+		ExtraConfig: map[string]interface{}{
+			proxy.Namespace: map[string]interface{}{
+				"sequential": true,
+			},
+		},
+	}
+
+	success := IsValidSequentialEndpoint(endpoint)
+
+	if !success {
+		t.Error("Endpoint expected valid but receive invalid")
+	}
+}
+
+func TestIsValidSequentialEndpoint_wrong_config_not_given(t *testing.T) {
+
+	endpoint := &config.EndpointConfig{
+		Endpoint: "/correct",
+		Method:   "PUT",
+		Backend: []*config.Backend{
+			{
+				Method: "GET",
+			},
+			{
+				Method: "PUT",
+			},
+		},
+		ExtraConfig: map[string]interface{}{},
+	}
+
+	success := IsValidSequentialEndpoint(endpoint)
+
+	if success {
+		t.Error("Endpoint expected invalid but receive valid")
+	}
+}
+
+func TestIsValidSequentialEndpoint_wrong_config_set_false(t *testing.T) {
+
+	endpoint := &config.EndpointConfig{
+		Endpoint: "/correct",
+		Method:   "PUT",
+		Backend: []*config.Backend{
+			{
+				Method: "GET",
+			},
+			{
+				Method: "PUT",
+			},
+		},
+		ExtraConfig: map[string]interface{}{
+			proxy.Namespace: map[string]interface{}{
+				"sequential": false,
+			},
+		}}
+
+	success := IsValidSequentialEndpoint(endpoint)
+
+	if success {
+		t.Error("Endpoint expected invalid but receive valid")
+	}
+}
+
+func TestIsValidSequentialEndpoint_wrong_order(t *testing.T) {
+
+	endpoint := &config.EndpointConfig{
+		Endpoint: "/correct",
+		Method:   "PUT",
+		Backend: []*config.Backend{
+			{
+				Method: "PUT",
+			},
+			{
+				Method: "GET",
+			},
+		},
+		ExtraConfig: map[string]interface{}{
+			proxy.Namespace: map[string]interface{}{
+				"sequential": true,
+			},
+		},
+	}
+
+	success := IsValidSequentialEndpoint(endpoint)
+
+	if success {
+		t.Error("Endpoint expected invalid but receive valid")
+	}
+}
+
+func TestIsValidSequentialEndpoint_wrong_all_non_get(t *testing.T) {
+
+	endpoint := &config.EndpointConfig{
+		Endpoint: "/correct",
+		Method:   "PUT",
+		Backend: []*config.Backend{
+			{
+				Method: "POST",
+			},
+			{
+				Method: "PUT",
+			},
+		},
+		ExtraConfig: map[string]interface{}{
+			proxy.Namespace: map[string]interface{}{
+				"sequential": true,
+			},
+		},
+	}
+
+	success := IsValidSequentialEndpoint(endpoint)
+
+	if success {
+		t.Error("Endpoint expected invalid but receive valid")
+	}
+}

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -123,23 +123,9 @@ func (r httpRouter) registerKrakendEndpoint(method string, endpoint *config.Endp
 	method = strings.ToTitle(method)
 	path := endpoint.Endpoint
 	if method != http.MethodGet && totBackends > 1 {
-		if endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"] == nil {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
+		if !router.IsValidSequentialEndpoint(endpoint) {
+			r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
 			return
-		}
-
-		proxyCfg := endpoint.ExtraConfig["github.com/devopsfaith/krakend/proxy"].(map[string]interface{})
-		if proxyCfg["sequential"] == false {
-			r.cfg.Logger.Error(method, "endpoints must have a single backend! Ignoring", path)
-			return
-		}
-
-		for i, backend := range endpoint.Backend {
-			r.cfg.Logger.Info(i, " -> ", backend.Method)
-			if backend.Method != http.MethodGet && (i+1) != totBackends {
-				r.cfg.Logger.Error(method, " endpoints with sequential enabled is only the last one is allowed to be non GET! Ignoring", path)
-				return
-			}
 		}
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -305,6 +305,12 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 			expHeaders: defaultHeaders,
 			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":["123.45.67.89"]}}`,
 		},
+		{
+			method:     "PUT",
+			name:       "sequence-accept",
+			url:        "/sequence-accept",
+			expHeaders: defaultHeaders,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/krakend.json
+++ b/test/krakend.json
@@ -356,6 +356,31 @@
                     "url_pattern": "/"
                 }
             ]
+        },
+        {
+            "endpoint": "/sequence-accept",
+            "method": "PUT",
+            "extra_config": {
+                "github.com/devopsfaith/krakend/proxy": {
+                    "sequential": true
+                }
+            },
+            "backend": [
+                {
+                    "method": "GET",
+                    "host": [
+                        "{{.b3}}"
+                    ],
+                    "url_pattern": "/"
+                },
+                {
+                    "method": "PUT",
+                    "host": [
+                        "{{.b3}}"
+                    ],
+                    "url_pattern": "/"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
You can use now the sequential proxy with POST, PUT and DELETE methods if you only use GET methods before.
#359