### PR TITLE
mTLS on the server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -240,6 +240,7 @@ type TLS struct {
 	CurvePreferences         []uint16 `mapstructure:"curve_preferences"`
 	PreferServerCipherSuites bool     `mapstructure:"prefer_server_cipher_suites"`
 	CipherSuites             []uint16 `mapstructure:"cipher_suites"`
+	EnableMTLS               bool     `mapstructure:"enable_mtls"`
 }
 
 // ExtraConfig is a type to store extra configurations for customized behaviours

--- a/config/parser.go
+++ b/config/parser.go
@@ -192,6 +192,7 @@ func (p *parseableServiceConfig) normalize() ServiceConfig {
 			CurvePreferences:         p.TLS.CurvePreferences,
 			PreferServerCipherSuites: p.TLS.PreferServerCipherSuites,
 			CipherSuites:             p.TLS.CipherSuites,
+			EnableMTLS:               p.TLS.EnableMTLS,
 		}
 	}
 	if p.ExtraConfig != nil {
@@ -214,6 +215,7 @@ type parseableTLS struct {
 	CurvePreferences         []uint16 `json:"curve_preferences"`
 	PreferServerCipherSuites bool     `json:"prefer_server_cipher_suites"`
 	CipherSuites             []uint16 `json:"cipher_suites"`
+	EnableMTLS               bool     `json:"enable_mtls"`
 }
 
 type parseableEndpointConfig struct {


### PR DESCRIPTION
This PR introduces support for mTLS between clients and the KrakenD gateway