### PR TITLE
Add a health check endpoint

### DIFF
--- a/router/chi/router.go
+++ b/router/chi/router.go
@@ -83,6 +83,8 @@ func (r chiRouter) Run(cfg config.ServiceConfig) {
 		r.registerDebugEndpoints()
 	}
 
+	r.cfg.Engine.Get("/__health", mux.HealthHandler)
+
 	router.InitHTTPDefaultTransport(cfg)
 
 	r.registerKrakendEndpoints(cfg.Endpoints)

--- a/router/gin/router.go
+++ b/router/gin/router.go
@@ -87,6 +87,10 @@ func (r ginRouter) Run(cfg config.ServiceConfig) {
 		r.cfg.Engine.Any("/__debug/*param", DebugHandler(r.cfg.Logger))
 	}
 
+	r.cfg.Engine.GET("/__health", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+
 	r.registerKrakendEndpoints(cfg.Endpoints)
 
 	r.cfg.Engine.NoRoute(func(c *gin.Context) {

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -77,6 +77,12 @@ type httpRouter struct {
 	RunServer RunServerFunc
 }
 
+// HealthHandler is a dummy http.HandlerFunc implementation for exposing a health check endpoint
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"status": "ok"}`))
+}
+
 // Run implements the router interface
 func (r httpRouter) Run(cfg config.ServiceConfig) {
 	if cfg.Debug {
@@ -95,6 +101,7 @@ func (r httpRouter) Run(cfg config.ServiceConfig) {
 			r.cfg.Engine.Handle(r.cfg.DebugPattern, method, debugHandler)
 		}
 	}
+	r.cfg.Engine.Handle("/__health", "GET", http.HandlerFunc(HealthHandler))
 
 	router.InitHTTPDefaultTransport(cfg)
 

--- a/router/mux/router.go
+++ b/router/mux/router.go
@@ -80,7 +80,7 @@ type httpRouter struct {
 // HealthHandler is a dummy http.HandlerFunc implementation for exposing a health check endpoint
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status": "ok"}`))
+	w.Write([]byte(`{"status":"ok"}`))
 }
 
 // Run implements the router interface

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -125,6 +125,12 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 		expStatusCode int
 	}{
 		{
+			name:    "health_check",
+			url:     "/__health",
+			headers: map[string]string{},
+			expBody: `{"status":"ok"}`,
+		},
+		{
 			name:       "static",
 			url:        "/static",
 			headers:    map[string]string{},


### PR DESCRIPTION
this PR introduces a new gateway endpoint at `/__health` for probing the readiness of the gateway