### PR TITLE
pass original request host in X-Forwarded-Host header

### DIFF
--- a/router/chi/endpoint_test.go
+++ b/router/chi/endpoint_test.go
@@ -61,7 +61,7 @@ func TestEndpointHandler_okAllParams(t *testing.T) {
 		timeout:            10,
 		proxy:              p,
 		method:             "GET",
-		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""]},"params":{"Param":"a"},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
+		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""],"X-Forwarded-Host":["127.0.0.1:8080"]},"params":{"Param":"a"},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
 		expectedCache:      "public, max-age=21600",
 		expectedContent:    "application/json",
 		expectedStatusCode: http.StatusOK,

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -96,7 +96,7 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 			params[strings.Title(param.Key[:1])+param.Key[1:]] = param.Value
 		}
 
-		headers := make(map[string][]string, 2+len(headersToSend))
+		headers := make(map[string][]string, 3+len(headersToSend))
 
 		for _, k := range headersToSend {
 			if k == requestParamsAsterisk {

--- a/router/gin/endpoint.go
+++ b/router/gin/endpoint.go
@@ -111,6 +111,7 @@ func NewRequest(headersToSend []string) func(*gin.Context, []string) *proxy.Requ
 		}
 
 		headers["X-Forwarded-For"] = []string{c.ClientIP()}
+		headers["X-Forwarded-Host"] = []string{c.Request.Host}
 		// if User-Agent is not forwarded using headersToSend, we set
 		// the KrakenD router User Agent value
 		if _, ok := headers["User-Agent"]; !ok {

--- a/router/gin/endpoint_test.go
+++ b/router/gin/endpoint_test.go
@@ -70,7 +70,7 @@ func TestEndpointHandler_okAllParams(t *testing.T) {
 		timeout:            10,
 		proxy:              p,
 		method:             "GET",
-		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""]},"params":{"Param":"a"},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
+		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""],"X-Forwarded-Host":["127.0.0.1:8080"]},"params":{"Param":"a"},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
 		expectedCache:      "public, max-age=21600",
 		expectedContent:    "application/json; charset=utf-8",
 		expectedStatusCode: http.StatusOK,

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -113,7 +113,7 @@ var NewRequest = NewRequestBuilder(NoopParamExtractor)
 func NewRequestBuilder(paramExtractor ParamExtractor) RequestBuilder {
 	return func(r *http.Request, queryString, headersToSend []string) *proxy.Request {
 		params := paramExtractor(r)
-		headers := make(map[string][]string, 2+len(headersToSend))
+		headers := make(map[string][]string, 3+len(headersToSend))
 
 		for _, k := range headersToSend {
 			if k == requestParamsAsterisk {

--- a/router/mux/endpoint.go
+++ b/router/mux/endpoint.go
@@ -128,6 +128,7 @@ func NewRequestBuilder(paramExtractor ParamExtractor) RequestBuilder {
 		}
 
 		headers["X-Forwarded-For"] = []string{clientIP(r)}
+		headers["X-Forwarded-Host"] = []string{r.Host}
 		// if User-Agent is not forwarded using headersToSend, we set
 		// the KrakenD router User Agent value
 		if _, ok := headers["User-Agent"]; !ok {

--- a/router/mux/endpoint_test.go
+++ b/router/mux/endpoint_test.go
@@ -56,7 +56,7 @@ func TestEndpointHandler_okAllParams(t *testing.T) {
 		timeout:            10,
 		proxy:              p,
 		method:             "GET",
-		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""]},"params":{},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
+		expectedBody:       `{"headers":{"Content-Type":["application/json"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":[""],"X-Forwarded-Host":["127.0.0.1:8081"]},"params":{},"query":{"a":["42"],"b":["1"],"c[]":["x","y"],"d":["1","2"]}}`,
 		expectedCache:      "public, max-age=21600",
 		expectedContent:    "application/json",
 		expectedStatusCode: http.StatusOK,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -203,28 +203,28 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 			url:        "/querystring-params-test/no-params?a=1&b=2&c=3",
 			headers:    map[string]string{},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"]},"path":"/no-params","query":{}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"]},"path":"/no-params","query":{}}`, cfg.Port),
 		},
 		{
 			name:       "querystring-params-optional-query-params",
 			url:        "/querystring-params-test/query-params?a=1&b=2&c=3",
 			headers:    map[string]string{},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"]},"path":"/query-params","query":{"a":["1"],"b":["2"]}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"]},"path":"/query-params","query":{"a":["1"],"b":["2"]}}`, cfg.Port),
 		},
 		{
 			name:       "querystring-params-mandatory-query-params",
 			url:        "/querystring-params-test/url-params/some?a=1&b=2&c=3",
 			headers:    map[string]string{},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"]},"path":"/url-params","query":{"p":["some"]}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"]},"path":"/url-params","query":{"p":["some"]}}`, cfg.Port),
 		},
 		{
 			name:       "querystring-params-all",
 			url:        "/querystring-params-test/all-params?a=1&b=2&c=3",
 			headers:    map[string]string{},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"]},"path":"/all-params","query":{"a":["1"],"b":["2"],"c":["3"]}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"]},"path":"/all-params","query":{"a":["1"],"b":["2"],"c":["3"]}}`, cfg.Port),
 		},
 		{
 			name: "header-params-none",
@@ -234,7 +234,7 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 				"X-TEST-2": "none",
 			},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"]},"path":"/no-params","query":{}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"]},"path":"/no-params","query":{}}`, cfg.Port),
 		},
 		{
 			name: "header-params-filter",
@@ -244,7 +244,7 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 				"X-TEST-2": "none",
 			},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Test-1":["some"]},"path":"/filter-params","query":{}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-Host":["localhost:%d"],"X-Test-1":["some"]},"path":"/filter-params","query":{}}`, cfg.Port),
 		},
 		{
 			name: "header-params-all",
@@ -255,7 +255,7 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 				"User-Agent": "KrakenD Test",
 			},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Test"],"X-Forwarded-Via":["KrakenD Version undefined"],"X-Test-1":["some"],"X-Test-2":["none"]},"path":"/all-params","query":{}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Test"],"X-Forwarded-Host":["localhost:%d"],"X-Forwarded-Via":["KrakenD Version undefined"],"X-Test-1":["some"],"X-Test-2":["none"]},"path":"/all-params","query":{}}`, cfg.Port),
 		},
 		{
 			name:       "sequential ok",
@@ -309,7 +309,7 @@ func testKrakenD(t *testing.T, runRouter func(logging.Logger, *config.ServiceCon
 				"x-forwarded-for": "123.45.67.89",
 			},
 			expHeaders: defaultHeaders,
-			expBody:    `{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":["123.45.67.89"]}}`,
+			expBody:    fmt.Sprintf(`{"headers":{"Accept-Encoding":["gzip"],"User-Agent":["KrakenD Version undefined"],"X-Forwarded-For":["123.45.67.89"],"X-Forwarded-Host":["localhost:%d"]}}`, cfg.Port),
 		},
 		{
 			method:     "PUT",


### PR DESCRIPTION
This PR will pass original Host header received by KrakenD as X-Forwarded-Host to backend services in the same way X-Forwarded-For is sent