### PR TITLE
fix for logger

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -45,7 +45,7 @@ var (
 		"CRITICAL": LEVEL_CRITICAL,
 	}
 	// NoOp is the NO-OP logger
-	NoOp, _ = NewLogger("CRITICAL", ioutil.Discard, "")
+	NoOp, _ = NewNopLogger("CRITICAL", ioutil.Discard, "")
 )
 
 // NewLogger creates and returns a Logger object

--- a/logging/noplog.go
+++ b/logging/noplog.go
@@ -1,0 +1,38 @@
+package logging
+
+import (
+	"io"
+	"os"
+)
+
+type NopLogger struct {
+	Level  int
+	Prefix string
+}
+
+// NewNopLogger creates and returns a NopLogger object
+func NewNopLogger(level string, out io.Writer, prefix string) (NopLogger, error) {
+	return NopLogger{Level: 0, Prefix: prefix}, nil
+}
+
+// Debug logs a message using DEBUG as log level.
+func (l *NopLogger) Debug(args ...interface{}) {}
+
+// Info logs a message using INFO as log level.
+func (l *NopLogger) Info(args ...interface{}) {}
+
+// Warning logs a message using WARNING as log level.
+func (l *NopLogger) Warning(args ...interface{}) {}
+
+// Error logs a message using ERROR as log level.
+func (l *NopLogger) Error(args ...interface{}) {}
+
+// Critical logs a message using CRITICAL as log level.
+func (l *NopLogger) Critical(args ...interface{}) {}
+
+// Fatal is equivalent to l.Critical(fmt.Sprint()) followed by a call to os.Exit(1).
+func (l *NopLogger) Fatal(args ...interface{}) {
+	os.Exit(1)
+}
+
+func (l *NopLogger) prependLog(args ...interface{}) {}


### PR DESCRIPTION
Looks like a little bug here.

The real issue from your example:
https://github.com/devopsfaith/krakend-examples/blob/master/httpcache/main.go

When the program was failed [we expected the FATAL message](https://github.com/devopsfaith/krakend-examples/blob/afcb8b057f5895436bc4363aaacd667e5542a838/httpcache/main.go#L31), but we don't have it, because this library had changed log level and set output to /dev/null. 